### PR TITLE
Work-arounds to make Djinni build on Windows with MSVC >=2013

### DIFF
--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -124,7 +124,12 @@ void jniThrowAssertionError(JNIEnv * env, const char * file, int line, const cha
     const char * file_basename = slash ? slash + 1 : file;
 
     char buf[256];
+#if (defined _MSC_VER) && (_MSC_VER < 1900)
+    // snprintf not implemented on MSVC prior to 2015 
+    _snprintf(buf, sizeof buf, "djinni (%s:%d): %s", file_basename, line, check);
+#else
     snprintf(buf, sizeof buf, "djinni (%s:%d): %s", file_basename, line, check);
+#endif
 
     jclass cassert = env->FindClass("java/lang/AssertionError");
     assert(cassert);
@@ -388,7 +393,11 @@ std::string jniUTF8FromString(JNIEnv * env, const jstring jstr) {
     return out;
 }
 
-__attribute__((weak))
+#ifdef _MSC_VER
+  // weak attribute not supported by MSVC
+#else
+  __attribute__((weak))
+#endif
 void jniSetPendingFromCurrent(JNIEnv * env, const char * /*ctx*/) noexcept {
     try {
         throw;

--- a/support-lib/jni/djinni_support.hpp
+++ b/support-lib/jni/djinni_support.hpp
@@ -194,7 +194,7 @@ private:
 };
 
 template <class C>
-const JniClassInitializer JniClass<C>::s_initializer { allocate };
+const JniClassInitializer JniClass<C>::s_initializer ( allocate );
 
 template <class C>
 std::unique_ptr<C> JniClass<C>::s_singleton;

--- a/support-lib/jni/djinni_support.hpp
+++ b/support-lib/jni/djinni_support.hpp
@@ -25,6 +25,12 @@
 
 #include <jni.h>
 
+// work-around for missing noexcept and constexpr support in MSVC prior to 2015
+#if (defined _MSC_VER) && (_MSC_VER < 1900)
+#  define noexcept _NOEXCEPT
+#  define constexpr
+#endif
+
 /*
  * Djinni support library
  */
@@ -57,7 +63,11 @@ void jniExceptionCheck(JNIEnv * env);
 /*
  * Set an AssertionError in env with message message, and then throw jni_exception_pending.
  */
-__attribute__((noreturn))
+#ifdef _MSC_VER
+  __declspec(noreturn)
+#else
+  __attribute__((noreturn))
+#endif
 void jniThrowAssertionError(JNIEnv * env, const char * file, int line, const char * check);
 
 #define DJINNI_ASSERT(check, env) \

--- a/support-lib/jni/djinni_support.hpp
+++ b/support-lib/jni/djinni_support.hpp
@@ -95,6 +95,10 @@ class GlobalRef : public std::unique_ptr<typename std::remove_pointer<PointerTyp
                                          GlobalRefDeleter> {
 public:
     GlobalRef() {}
+    GlobalRef(GlobalRef && obj)
+        : std::unique_ptr<typename std::remove_pointer<PointerType>::type, ::djinni::GlobalRefDeleter>(
+            std::move(obj)
+        ) {}
     GlobalRef(JNIEnv * env, PointerType localRef)
         : std::unique_ptr<typename std::remove_pointer<PointerType>::type, ::djinni::GlobalRefDeleter>(
             static_cast<PointerType>(env->NewGlobalRef(localRef)),

--- a/support-lib/jni/djinni_support.hpp
+++ b/support-lib/jni/djinni_support.hpp
@@ -96,9 +96,9 @@ class GlobalRef : public std::unique_ptr<typename std::remove_pointer<PointerTyp
 public:
     GlobalRef() {}
     GlobalRef(JNIEnv * env, PointerType localRef)
-        : std::unique_ptr<typename std::remove_pointer<PointerType>::type, GlobalRefDeleter>(
+        : std::unique_ptr<typename std::remove_pointer<PointerType>::type, ::djinni::GlobalRefDeleter>(
             static_cast<PointerType>(env->NewGlobalRef(localRef)),
-            GlobalRefDeleter{}
+            ::djinni::GlobalRefDeleter{}
         ) {}
 };
 
@@ -110,7 +110,7 @@ class LocalRef : public std::unique_ptr<typename std::remove_pointer<PointerType
 public:
     LocalRef() {}
     LocalRef(JNIEnv * /*env*/, PointerType localRef)
-        : std::unique_ptr<typename std::remove_pointer<PointerType>::type, LocalRefDeleter>(
+        : std::unique_ptr<typename std::remove_pointer<PointerType>::type, ::djinni::LocalRefDeleter>(
             localRef) {}
     explicit LocalRef(PointerType localRef)
         : std::unique_ptr<typename std::remove_pointer<PointerType>::type, LocalRefDeleter>(


### PR DESCRIPTION
Changes necessary to make Djinni build successfully on Windows with Microsoft Visual Studio 2013 and newer.