### PR TITLE
Generate interfaces in Java when possible

### DIFF
--- a/example/generated-src/java/com/dropbox/textsort/TextboxListener.java
+++ b/example/generated-src/java/com/dropbox/textsort/TextboxListener.java
@@ -3,6 +3,6 @@
 
 package com.dropbox.textsort;
 
-public abstract class TextboxListener {
-    public abstract void update(ItemList items);
+public interface TextboxListener {
+    public void update(ItemList items);
 }

--- a/example/handwritten-src/java/com/dropbox/textsort/TextboxListenerImpl.java
+++ b/example/handwritten-src/java/com/dropbox/textsort/TextboxListenerImpl.java
@@ -4,7 +4,7 @@ import android.widget.EditText;
 
 import java.util.ArrayList;
 
-public class TextboxListenerImpl extends TextboxListener {
+public class TextboxListenerImpl implements TextboxListener {
 
     private EditText mTextArea;
 

--- a/src/source/JavaGenerator.scala
+++ b/src/source/JavaGenerator.scala
@@ -143,7 +143,10 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
       writeDoc(w, doc)
 
       javaAnnotationHeader.foreach(w.wl)
-      w.w(s"public abstract class $javaClass$typeParamList").braced {
+      val isAbstractClass = i.ext.cpp || i.methods.exists(_.static) || i.consts.size > 0
+      val classPrefix = if (isAbstractClass) "abstract class" else "interface"
+      val methodPrefix = if (isAbstractClass) "abstract " else ""
+      w.w(s"public $classPrefix $javaClass$typeParamList").braced {
         val skipFirst = SkipFirst()
         generateJavaConstants(w, i.consts)
 
@@ -153,7 +156,7 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
           writeDoc(w, m.doc)
           val ret = m.ret.fold("void")(toJavaType(_))
           val params = m.params.map(p => toJavaType(p.ty) + " " + idJava.local(p.ident))
-          w.wl("public abstract " + ret + " " + idJava.method(m.ident) + params.mkString("(", ", ", ")") + throwException + ";")
+          w.wl(s"public $methodPrefix" + ret + " " + idJava.method(m.ident) + params.mkString("(", ", ", ")") + throwException + ";")
         }
         for (m <- i.methods if m.static) {
           skipFirst { w.wl }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ClientInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ClientInterface.java
@@ -3,7 +3,7 @@
 
 package com.dropbox.djinni.test;
 
-public abstract class ClientInterface {
+public interface ClientInterface {
     /** Returns record of given string */
-    public abstract ClientReturnedRecord getRecord(long recordId, String utf8string);
+    public ClientReturnedRecord getRecord(long recordId, String utf8string);
 }

--- a/test-suite/handwritten-src/java/com/dropbox/djinni/test/ClientInterfaceImpl.java
+++ b/test-suite/handwritten-src/java/com/dropbox/djinni/test/ClientInterfaceImpl.java
@@ -2,7 +2,7 @@ package com.dropbox.djinni.test;
 
 import static junit.framework.Assert.assertTrue;
 
-public class ClientInterfaceImpl extends ClientInterface {
+public class ClientInterfaceImpl implements ClientInterface {
     @Override
     public ClientReturnedRecord getRecord(long id, String utf8string) {
         if (!utf8string.equals("Non-ASCII / 非 ASCII 字符") && !utf8string.equals("Hello World!")) {


### PR DESCRIPTION
If the djinni interface doesn't contain constants or static members, then it
can be represented as an interface (not abstract class) in Java.
