### PR TITLE
Avoid unnecessary conversion and temporaries

### DIFF
--- a/support-lib/jni/HString.hpp
+++ b/support-lib/jni/HString.hpp
@@ -28,8 +28,8 @@ public:
         return jniUTF8FromString(jniEnv, j);
     }
 
-    static jstring toJava(JNIEnv* jniEnv, std::string c) {
-        return jniStringFromUTF8(jniEnv, c.c_str());
+    static jstring toJava(JNIEnv* jniEnv, const std::string & c) {
+        return jniStringFromUTF8(jniEnv, c);
     }
 };
 


### PR DESCRIPTION
Passing the result of c_str() to a function that takes std::string as argument is slow and redundant.