### PR TITLE
Correct namespace for ObjcProxy return types

### DIFF
--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -326,7 +326,7 @@ class ObjcGenerator(spec: Spec) extends Generator(spec) {
             w.wl(s"virtual ~$objcExtSelf () override;")
             w.wl(s"static std::shared_ptr<${withNs(spec.cppNamespace, idCpp.ty(ident.name))}> ${idCpp.method(ident.name + "_with_objc")} (id objcRef);")
             for (m <- i.methods) {
-              val ret = m.ret.fold("void")(toCppType(_))
+              val ret = m.ret.fold("void")(toCppType(_, spec.cppNamespace))
               val params = m.params.map(p => toCppParamType(p, spec.cppNamespace))
               w.wl(s"virtual $ret ${idCpp.method(m.ident)} ${params.mkString("(", ", ", ")")} override;")
             }
@@ -355,7 +355,7 @@ class ObjcGenerator(spec: Spec) extends Generator(spec) {
           }
           for (m <- i.methods) {
             w.wl
-            val ret = m.ret.fold("void")(toCppType(_))
+            val ret = m.ret.fold("void")(toCppType(_, spec.cppNamespace))
             val params = m.params.map(p => toCppParamType(p, spec.cppNamespace))
             w.wl(s"$ret $objcExtSelf::${idCpp.method(m.ident)} ${params.mkString("(", ", ", ")")}").braced {
               w.w("@autoreleasepool").braced {


### PR DESCRIPTION
This fixes the case where the Objective-C++ namespace is different from the C++ namespace.

In a code base I'm working on, for instance, the Objective-C++ namespace is set to "djinni_generated", whereas the C++ namespace is like "foo::bar". Djinni would produce broken Objective-C++ code before this patch in that configuration.

If these namespaces should always be identical, then either the C++ namespace should be forced single-level or the Objective-C++ namespace should be able to be multi-level. Currently, if one has picked a multi-level C++ namespace, one is forced to have a separate Objective-C++ namespace.

I'm guessing that the behavior prior to this patch is an accident, since the absolute C++ namespace is inserted on the type in the constructor.