### PR TITLE
src/support/sbt: Don't pass -XX:MaxPermSize to JDK 1.8+

### DIFF
--- a/src/support/sbt
+++ b/src/support/sbt
@@ -14,8 +14,22 @@ while [ -h "$loc" ]; do
 done
 base_dir=$(cd `dirname "$loc"` && pwd)
 
+# Just the first two digits of the version.
+java_version=$(java -version 2>&1 | sed -ne '1s/.*"\([0-9][0-9]*\.[0-9][0-9]*\)\..*/\1/p')
+
+if [[ "$java_version" == 1.[0-5] ]]; then
+    echo "Executing \"java -version\" reports \"$java_version\"." 1>&2
+    echo "We require at least Java 1.6." 1>&2
+    exit 1
+fi
+
+jvm_args=()
+if [[ "$java_version" == 1.[6-7] ]]; then
+    jvm_args+=(-XX:MaxPermSize=256M)  # Not relevant to JDK 1.8+
+fi
+
 java \
-    -Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M \
+    -Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled "${jvm_args[@]}" \
     -Djava.security.manager -Djava.security.policy="$base_dir/sbt.security.policy" \
     -jar "$base_dir/sbt-launch.jar" \
     -Dsbt.override.build.repos=true \


### PR DESCRIPTION
That option is deprecated in JDK 1.8 and causes a warning message.

(Hey, j4cbo -- try using [import-pull-request](https://github.com/cakoose/import-pull-request) to accept the request.  It avoids the stupid merge commit.)