### PR TITLE
Move declaration of the extended class for the extended record into the namespace.

### DIFF
--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -139,7 +139,6 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
 
     // Requiring the extended class
     if (r.ext.cpp) {
-      refs.hpp.add(s"class $self; // Requiring extended class")
       refs.cpp.add("#include "+q("../" + spec.cppFileIdentStyle(ident) + "." + spec.cppHeaderExt))
     }
 
@@ -147,6 +146,11 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
     def writeCppPrototype(w: IndentWriter) {
       writeDoc(w, doc)
       writeCppTypeParams(w, params)
+      if (r.ext.cpp) {
+        w.wl
+        w.wl(s"class $self; // Requiring extended class")
+        w.wl
+      }
       w.w("struct " + actualSelf + cppFinal).bracedSemi {
         generateHppConstants(w, r.consts)
         // Field definitions.


### PR DESCRIPTION
When you define an extended `record +c` declaration of the extended class was placed outside the namespace. In our case `Rect` class was declared outside the namespace and it was in conflict with existing struct `Rect` (from MacTypes.h) already being imported in the global namespace.