### PR TITLE
Upgrade Android example to expect latest SDK

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "19.1.0"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
         applicationId "com.dropbox.textsort"
         minSdkVersion 15
-        targetSdkVersion 19
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Without this Djinni looks for a specific older version.  There are no specific reasons to prefer any version, so I'm pegging it to the latest, which new developers should be most likely to have.  I found custom scripts online for automatically searching for the latest version, but don't want to pull in that level of complexity to our examples at the moment.