### PR TITLE
Build script improvements for paths with spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
-all: example_ios example_android
+all: example_ios example_android test
 
 clean:
-	-rm GypAndroid.mk
+	-ndk-build -C example/android/app/ clean
+	-xcodebuild -workspace example/objc/TextSort.xcworkspace -scheme TextSort -configuration 'Debug' -sdk iphonesimulator clean
 	-rm -rf libs/
 	-rm -rf obj/
 	-rm -rf build/
 	-rm -rf build_ios/
-	-ndk-build -C example/android/app/ clean
-	-xcodebuild -workspace example/objc/TextSort.xcworkspace -scheme TextSort -configuration 'Debug' -sdk iphonesimulator clean
+	-rm GypAndroid.mk
 
 # rule to lazily clone gyp
 # freeze gyp at the last version with android support
@@ -18,7 +18,7 @@ clean:
 # we specify a root target for android to prevent all of the targets from spidering out
 GypAndroid.mk: ./deps/gyp example/libtextsort.gyp support-lib/support_lib.gyp example/example.djinni
 	./example/run_djinni.sh
-	ANDROID_BUILD_TOP=dirname $(which ndk-build) deps/gyp/gyp --depth=. -f android -DOS=android -Icommon.gypi example/libtextsort.gyp --root-target=libtextsort_jni
+	ANDROID_BUILD_TOP=$(shell dirname `which ndk-build`) deps/gyp/gyp --depth=. -f android -DOS=android -Icommon.gypi example/libtextsort.gyp --root-target=libtextsort_jni
 
 # we specify a root target for android to prevent all of the targets from spidering out
 ./build_ios/example/libtextsort.xcodeproj: ./deps/gyp example/libtextsort.gyp support-lib/support_lib.gyp example/example.djinni
@@ -37,4 +37,7 @@ example_android: GypAndroid.mk
 	@echo "Apks produced at:"
 	@python example/glob.py example/ '*.apk'
 
-.PHONY: example_android example_ios clean all
+test:
+	make -C test-suite
+
+.PHONY: example_android example_ios test clean all

--- a/example/run_djinni.sh
+++ b/example/run_djinni.sh
@@ -13,7 +13,7 @@ while [ -h "$loc" ]; do
         loc="`dirname "$loc"`/$link"  # Relative link
     fi
 done
-base_dir=$(cd `dirname "$loc"` && pwd)
+base_dir=$(cd "`dirname "$loc"`" && pwd)
 
 temp_out="$base_dir/djinni-output-temp"
 
@@ -50,7 +50,7 @@ fi
 "$base_dir/../src/build"
 
 [ ! -e "$temp_out" ] || rm -r "$temp_out"
-$base_dir/../src/run-assume-built \
+"$base_dir/../src/run-assume-built" \
     --java-out "$temp_out/java" \
     --java-package $java_package \
     --ident-java-field mFooBar \

--- a/src/build
+++ b/src/build
@@ -12,7 +12,7 @@ while [ -h "$loc" ]; do
         loc="`dirname "$loc"`/$link"  # Relative link
     fi
 done
-base_dir=$(cd `dirname "$loc"` && pwd)
+base_dir=$(cd "`dirname "$loc"`" && pwd)
 
 need_to_build=0
 dependencies=("build.sbt" "project/plugins.sbt" "source")

--- a/src/run
+++ b/src/run
@@ -12,7 +12,7 @@ while [ -h "$loc" ]; do
         loc="`dirname "$loc"`/$link"  # Relative link
     fi
 done
-base_dir=$(cd `dirname "$loc"` && pwd)
+base_dir=$(cd "`dirname "$loc"`" && pwd)
 
 "$base_dir/build"
 exec "$base_dir/target/start" "$@"

--- a/src/run-assume-built
+++ b/src/run-assume-built
@@ -12,6 +12,6 @@ while [ -h "$loc" ]; do
         loc="`dirname "$loc"`/$link"  # Relative link
     fi
 done
-base_dir=$(cd `dirname "$loc"` && pwd)
+base_dir=$(cd "`dirname "$loc"`" && pwd)
 
 exec "$base_dir/target/start" "$@"

--- a/src/support/sbt
+++ b/src/support/sbt
@@ -12,7 +12,7 @@ while [ -h "$loc" ]; do
         loc="`dirname "$loc"`/$link"  # Relative link
     fi
 done
-base_dir=$(cd `dirname "$loc"` && pwd)
+base_dir=$(cd "`dirname "$loc"`" && pwd)
 
 # Just the first two digits of the version.
 java_version=$(java -version 2>&1 | sed -ne '1s/.*"\([0-9][0-9]*\.[0-9][0-9]*\)\..*/\1/p')

--- a/test-suite/run_djinni.sh
+++ b/test-suite/run_djinni.sh
@@ -13,7 +13,7 @@ while [ -h "$loc" ]; do
         loc="`dirname "$loc"`/$link"  # Relative link
     fi
 done
-base_dir=$(cd `dirname "$loc"` && pwd)
+base_dir=$(cd "`dirname "$loc"`" && pwd)
 
 temp_out="$base_dir/djinni-output-temp"
 
@@ -50,7 +50,7 @@ fi
 "$base_dir/../src/build"
 
 [ ! -e "$temp_out" ] || rm -r "$temp_out"
-$base_dir/../src/run-assume-built \
+"$base_dir/../src/run-assume-built" \
     --java-out "$temp_out/java" \
     --java-package $java_package \
     --ident-java-field mFooBar \


### PR DESCRIPTION
Everything works in a dir with spaces in the path, except for the
Android NDK build of the example, which is a limitation of the NDK.
I also made some cleanups to the Makefile along the way: Reordered the
clean rule to clean up gyp artifacts after they’re regenerated (from
inside NDK), and to directly access the test suite.

Closes issue #23