### PR TITLE
Enable NRVO in JNI's Binary::toCpp

### DIFF
--- a/support-lib/jni/Marshal.hpp
+++ b/support-lib/jni/Marshal.hpp
@@ -158,7 +158,7 @@ namespace djinni
             jniExceptionCheck(jniEnv);
 
             if (!length) {
-                return {};
+                return ret;
             }
 
             {


### PR DESCRIPTION
This optimization is usually disabled if not all paths return the same local object.