### PR TITLE
objc: also implement `hash` when implementing `isEqual:`

### DIFF
--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -291,6 +291,33 @@ class ObjcGenerator(spec: Spec) extends Generator(spec) {
           }
           w.wl(";")
         }
+        w.wl
+
+        w.wl("- (NSUInteger)hash")
+        w.braced {
+          w.w(s"return ").nestedN(2) {
+            w.w(s"NSStringFromClass([self class]).hash")
+            for (f <- r.fields) {
+              w.wl(" ^")
+              f.ty.resolved.base match {
+                case MOptional =>
+                  f.ty.resolved.args.head.base match {
+                    case df: MDef if df.defType == DEnum =>
+                      w.w(s"(NSUInteger)self.${idObjc.field(f.ident)}")
+                    case _ => w.w(s"self.${idObjc.field(f.ident)}.hash")
+                  }
+                case t: MPrimitive => w.w(s"(NSUInteger)self.${idObjc.field(f.ident)}")
+                case df: MDef => df.defType match {
+                  case DEnum => w.w(s"(NSUInteger)self.${idObjc.field(f.ident)}")
+                  case _ => w.w(s"self.${idObjc.field(f.ident)}.hash")
+                }
+                case _ => w.w(s"self.${idObjc.field(f.ident)}.hash")
+              }
+            }
+          }
+          w.wl(";")
+        }
+        w.wl
       }
 
       def generatePrimitiveOrder(ident: Ident, w: IndentWriter): Unit = {
@@ -326,8 +353,8 @@ class ObjcGenerator(spec: Spec) extends Generator(spec) {
           }
           w.wl("return NSOrderedSame;")
         }
+        w.wl
       }
-      w.wl
       w.wl("@end")
     })
   }

--- a/test-suite/generated-src/objc/DBAssortedIntegers.mm
+++ b/test-suite/generated-src/objc/DBAssortedIntegers.mm
@@ -44,4 +44,17 @@
             ((self.oSixtyfour == nil && typedOther.oSixtyfour == nil) || (self.oSixtyfour != nil && [self.oSixtyfour isEqual:typedOther.oSixtyfour]));
 }
 
+- (NSUInteger)hash
+{
+    return NSStringFromClass([self class]).hash ^
+            (NSUInteger)self.eight ^
+            (NSUInteger)self.sixteen ^
+            (NSUInteger)self.thirtytwo ^
+            (NSUInteger)self.sixtyfour ^
+            self.oEight.hash ^
+            self.oSixteen.hash ^
+            self.oThirtytwo.hash ^
+            self.oSixtyfour.hash;
+}
+
 @end

--- a/test-suite/generated-src/objc/DBClientReturnedRecord.mm
+++ b/test-suite/generated-src/objc/DBClientReturnedRecord.mm
@@ -18,5 +18,4 @@
     return self;
 }
 
-
 @end

--- a/test-suite/generated-src/objc/DBConstants.mm
+++ b/test-suite/generated-src/objc/DBConstants.mm
@@ -39,5 +39,4 @@ DBConstants * __nonnull const DBConstantsObjectConstant = [[DBConstants alloc] i
     return self;
 }
 
-
 @end

--- a/test-suite/generated-src/objc/DBDateRecord.mm
+++ b/test-suite/generated-src/objc/DBDateRecord.mm
@@ -14,5 +14,4 @@
     return self;
 }
 
-
 @end

--- a/test-suite/generated-src/objc/DBMapDateRecord.mm
+++ b/test-suite/generated-src/objc/DBMapDateRecord.mm
@@ -14,5 +14,4 @@
     return self;
 }
 
-
 @end

--- a/test-suite/generated-src/objc/DBMapListRecord.mm
+++ b/test-suite/generated-src/objc/DBMapListRecord.mm
@@ -14,5 +14,4 @@
     return self;
 }
 
-
 @end

--- a/test-suite/generated-src/objc/DBMapRecord.mm
+++ b/test-suite/generated-src/objc/DBMapRecord.mm
@@ -14,5 +14,4 @@
     return self;
 }
 
-
 @end

--- a/test-suite/generated-src/objc/DBNestedCollection.mm
+++ b/test-suite/generated-src/objc/DBNestedCollection.mm
@@ -14,5 +14,4 @@
     return self;
 }
 
-
 @end

--- a/test-suite/generated-src/objc/DBPrimitiveList.mm
+++ b/test-suite/generated-src/objc/DBPrimitiveList.mm
@@ -14,5 +14,4 @@
     return self;
 }
 
-
 @end

--- a/test-suite/generated-src/objc/DBRecordWithDerivings.mm
+++ b/test-suite/generated-src/objc/DBRecordWithDerivings.mm
@@ -25,6 +25,14 @@
     return self.key1 == typedOther.key1 &&
             [self.key2 isEqualToString:typedOther.key2];
 }
+
+- (NSUInteger)hash
+{
+    return NSStringFromClass([self class]).hash ^
+            (NSUInteger)self.key1 ^
+            self.key2.hash;
+}
+
 - (NSComparisonResult)compare:(DBRecordWithDerivings *)other
 {
     NSComparisonResult tempResult;

--- a/test-suite/generated-src/objc/DBRecordWithNestedDerivings.mm
+++ b/test-suite/generated-src/objc/DBRecordWithNestedDerivings.mm
@@ -25,6 +25,14 @@
     return self.key == typedOther.key &&
             [self.rec isEqual:typedOther.rec];
 }
+
+- (NSUInteger)hash
+{
+    return NSStringFromClass([self class]).hash ^
+            (NSUInteger)self.key ^
+            self.rec.hash;
+}
+
 - (NSComparisonResult)compare:(DBRecordWithNestedDerivings *)other
 {
     NSComparisonResult tempResult;

--- a/test-suite/generated-src/objc/DBSetRecord.mm
+++ b/test-suite/generated-src/objc/DBSetRecord.mm
@@ -14,5 +14,4 @@
     return self;
 }
 
-
 @end


### PR DESCRIPTION
Apple [docs](https://developer.apple.com/library/prerelease/ios/documentation/Cocoa/Reference/Foundation/Protocols/NSObject_Protocol/index.html#//apple_ref/occ/intfm/NSObject/isEqual:) mention that one should always override `hash` when
implementing equality and overriding `isEqual:`.

This is not the smartest hashing but better than nothing.