### PR TITLE
Allow imported IDL files to be in same directory as parent IDL file

### DIFF
--- a/src/source/parser.scala
+++ b/src/source/parser.scala
@@ -38,7 +38,11 @@ private object IdlParser extends RegexParsers {
 
   def importFile: Parser[File] = "@import \"" ~> filePath <~ "\"" ^^ {
     x => {
-      val newPath = fileStack.top.getParent() + "/" + x
+      val parent: Option[String] = Option(fileStack.top.getParent())
+      val newPath = parent match {
+        case Some(_) => parent + "/" + x
+        case None => x
+      }
       new File(newPath)
     }
   }


### PR DESCRIPTION
Java.io.File.getParent() previously would return null and the import file path will end up as "null/file.djinni", which fails.
Use case is you have a bunch of IDL files in a directory and have a single file that imports them all, ie.

main.djinni \
    @import "filename.djinni"

filename.djinni \
    ...