### PR TITLE
Cast handle

### DIFF
--- a/src/source/ObjcppGenerator.scala
+++ b/src/source/ObjcppGenerator.scala
@@ -178,7 +178,7 @@ class ObjcppGenerator(spec: Spec) extends Generator(spec) {
               w.wl(s"$ret ${idCpp.method(m.ident)}${params.mkString("(", ", ", ")")} override").braced {
                 w.w("@autoreleasepool").braced {
                   val ret = m.ret.fold("")(_ => "auto r = ")
-                  val call = "[Handle::get() " + idObjc.method(m.ident)
+                  val call = s"[(id<$self>)Handle::get() ${idObjc.method(m.ident)}"
                   writeAlignedObjcCall(w, ret + call, m.params, "]", p => (idObjc.field(p.ident), s"(${objcppMarshal.fromCpp(p.ty, idCpp.local(p.ident))})"))
                   w.wl(";")
                   m.ret.fold()(r => { w.wl(s"return ${objcppMarshal.toCpp(r, "r")};") })

--- a/test-suite/generated-src/objc/DBClientInterface+Private.mm
+++ b/test-suite/generated-src/objc/DBClientInterface+Private.mm
@@ -20,16 +20,16 @@ public:
     ::ClientReturnedRecord get_record(int64_t record_id, const std::string & utf8string, const std::experimental::optional<std::string> & misc) override
     {
         @autoreleasepool {
-            auto r = [Handle::get() getRecord:(::djinni::I64::fromCpp(record_id))
-                                   utf8string:(::djinni::String::fromCpp(utf8string))
-                                         misc:(::djinni::Optional<std::experimental::optional, ::djinni::String>::fromCpp(misc))];
+            auto r = [(id<DBClientInterface>)Handle::get() getRecord:(::djinni::I64::fromCpp(record_id))
+                                                          utf8string:(::djinni::String::fromCpp(utf8string))
+                                                                misc:(::djinni::Optional<std::experimental::optional, ::djinni::String>::fromCpp(misc))];
             return ::djinni_generated::ClientReturnedRecord::toCpp(r);
         }
     }
     std::string return_str() override
     {
         @autoreleasepool {
-            auto r = [Handle::get() returnStr];
+            auto r = [(id<DBClientInterface>)Handle::get() returnStr];
             return ::djinni::String::toCpp(r);
         }
     }

--- a/test-suite/generated-src/objc/DBToken+Private.mm
+++ b/test-suite/generated-src/objc/DBToken+Private.mm
@@ -50,7 +50,7 @@ public:
     std::string whoami() override
     {
         @autoreleasepool {
-            auto r = [Handle::get() whoami];
+            auto r = [(id<DBToken>)Handle::get() whoami];
             return ::djinni::String::toCpp(r);
         }
     }


### PR DESCRIPTION
This prevents Djinni-generated code from causing warnings when compiled with
`-Wstrict-selector-match`. See ["A big weakness in Objective-C's weak typing"](http://www.cocoawithlove.com/2011/06/big-weakness-of-objective-c-weak-typing.html) for details.