### PR TITLE
Returning immutable Objective-C collections when converting from C++

### DIFF
--- a/support-lib/objc/DJIMarshal+Private.h
+++ b/support-lib/objc/DJIMarshal+Private.h
@@ -203,7 +203,7 @@ public:
         for(const auto& value : v) {
             [array addObject:T::Boxed::fromCpp(value)];
         }
-        return array;
+        return [array copy];
     }
 };
 
@@ -233,7 +233,7 @@ public:
         for(const auto& value : s) {
             [set addObject:T::Boxed::fromCpp(value)];
         }
-        return set;
+        return [set copy];
     }
 };
 
@@ -266,7 +266,7 @@ public:
         for(const auto& kvp : m) {
             [map setObject:Value::Boxed::fromCpp(kvp.second) forKey:Key::Boxed::fromCpp(kvp.first)];
         }
-        return map;
+        return [map copy];
     }
 };
 


### PR DESCRIPTION
The specified `ObjcType` in all of these is the immutable counterpart (`NSArray,` `NSSet`, and `NSDictionary`) so returning a mutable instance was unnecessary. This has a few added benefits:
- **Guarantees immutability**: even though the types were immutable, one can (though obviously discouraged) mutate the instances.
- **Optimizes memory usage**: it's common in Objective-C to perform *defensive copying* (I've seen Djinni does this in a few places). By copying early we guarantee that only one copy is made, rather than each class creating its own copy (remember that calling `-copy` on an immutable instance simply returns `this`).
- **Optimizes performance**: immutable implementations of these classes in `Foundation` are potentially better optimized for searching and fetching, since they don't need to be optimized for insertion, deletion, or update.