### PR TITLE
Objective-C generated classes copy collection types in constructor

### DIFF
--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -187,6 +187,9 @@ class ObjcGenerator(spec: Spec) extends Generator(spec) {
     def checkMutable(tm: MExpr): Boolean = tm.base match {
       case MOptional => checkMutable(tm.args.head)
       case MString => true
+      case MList => true
+      case MSet => true
+      case MMap => true
       case MBinary => true
       case _ => false
     }

--- a/test-suite/generated-src/objc/DBMapDateRecord.mm
+++ b/test-suite/generated-src/objc/DBMapDateRecord.mm
@@ -9,7 +9,7 @@
 - (nonnull instancetype)initWithDatesById:(nonnull NSDictionary *)datesById
 {
     if (self = [super init]) {
-        _datesById = datesById;
+        _datesById = [datesById copy];
     }
     return self;
 }

--- a/test-suite/generated-src/objc/DBMapListRecord.mm
+++ b/test-suite/generated-src/objc/DBMapListRecord.mm
@@ -9,7 +9,7 @@
 - (nonnull instancetype)initWithMapList:(nonnull NSArray *)mapList
 {
     if (self = [super init]) {
-        _mapList = mapList;
+        _mapList = [mapList copy];
     }
     return self;
 }

--- a/test-suite/generated-src/objc/DBMapRecord.mm
+++ b/test-suite/generated-src/objc/DBMapRecord.mm
@@ -10,8 +10,8 @@
                                imap:(nonnull NSDictionary *)imap
 {
     if (self = [super init]) {
-        _map = map;
-        _imap = imap;
+        _map = [map copy];
+        _imap = [imap copy];
     }
     return self;
 }

--- a/test-suite/generated-src/objc/DBNestedCollection.mm
+++ b/test-suite/generated-src/objc/DBNestedCollection.mm
@@ -9,7 +9,7 @@
 - (nonnull instancetype)initWithSetList:(nonnull NSArray *)setList
 {
     if (self = [super init]) {
-        _setList = setList;
+        _setList = [setList copy];
     }
     return self;
 }

--- a/test-suite/generated-src/objc/DBPrimitiveList.mm
+++ b/test-suite/generated-src/objc/DBPrimitiveList.mm
@@ -9,7 +9,7 @@
 - (nonnull instancetype)initWithList:(nonnull NSArray *)list
 {
     if (self = [super init]) {
-        _list = list;
+        _list = [list copy];
     }
     return self;
 }

--- a/test-suite/generated-src/objc/DBSetRecord.mm
+++ b/test-suite/generated-src/objc/DBSetRecord.mm
@@ -10,8 +10,8 @@
                                iset:(nonnull NSSet *)iset
 {
     if (self = [super init]) {
-        _set = set;
-        _iset = iset;
+        _set = [set copy];
+        _iset = [iset copy];
     }
     return self;
 }


### PR DESCRIPTION
This is a small follow up to #123. The `ObjcGenerator` was already correctly set up to automatically copy `NSString` instances to ensure that if an `NSMutableString` instance was passed instead, an immutable copy was created.
With this change the same is true for `NSSet`, `NSArray`, and `NSDictionary` properties.

Note that thanks to #123 this should not have a performance impact (neither memory or CPU), since at most only one copy will be made.