### PR TITLE
Returning immutable Objective-C collections when converting from C++ (alternative approach)

### DIFF
--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -187,6 +187,9 @@ class ObjcGenerator(spec: Spec) extends Generator(spec) {
     def checkMutable(tm: MExpr): Boolean = tm.base match {
       case MOptional => checkMutable(tm.args.head)
       case MString => true
+      case MList => true
+      case MSet => true
+      case MMap => true
       case MBinary => true
       case _ => false
     }

--- a/src/source/ObjcppGenerator.scala
+++ b/src/source/ObjcppGenerator.scala
@@ -71,7 +71,7 @@ class ObjcppGenerator(spec: Spec) extends Generator(spec) {
 
     refs.privHeader.add("#include <memory>")
     refs.privHeader.add("!#include " + q(spec.objcppIncludeCppPrefix + spec.cppFileIdentStyle(ident) + "." + spec.cppHeaderExt))
-    refs.body.add("!#import " + q(spec.objcppIncludeObjcPrefix + headerName(ident)))
+    refs.privHeader.add("!#import " + q(spec.objcppIncludeObjcPrefix + headerName(ident)))
 
     def writeObjcFuncDecl(method: Interface.Method, w: IndentWriter) {
       val label = if (method.static) "+" else "-"

--- a/support-lib/objc/DJIMarshal+Private.h
+++ b/support-lib/objc/DJIMarshal+Private.h
@@ -199,14 +199,13 @@ public:
 
     static ObjcType fromCpp(const CppType& v) {
         assert(v.size() <= std::numeric_limits<NSUInteger>::max());
-
         NSUInteger const count = static_cast<NSUInteger>(v.size());
-        NSUInteger idx = 0;
-        EObjcType __strong array[count];
+        std::vector<EObjcType> array;
+        array.reserve(count);
         for(const auto& value : v) {
-            array[idx++] = T::Boxed::fromCpp(value);
+            array.push_back(T::Boxed::fromCpp(value));
         }
-        return [NSArray arrayWithObjects:array count:count];
+        return [NSArray arrayWithObjects:array.data() count:count];
     }
 };
 
@@ -233,12 +232,12 @@ public:
     static ObjcType fromCpp(const CppType& s) {
         assert(s.size() <= std::numeric_limits<NSUInteger>::max());
         NSUInteger const count = static_cast<NSUInteger>(s.size());
-        NSUInteger idx = 0;
-        EObjcType __strong set[count];
+        std::vector<EObjcType> set;
+        set.reserve(count);
         for(const auto& value : s) {
-            set[idx++] = T::Boxed::fromCpp(value);
+            set.push_back(T::Boxed::fromCpp(value));
         }
-        return [NSSet setWithObjects:set count:count];;
+        return [NSSet setWithObjects:set.data() count:count];
     }
 };
 
@@ -268,14 +267,15 @@ public:
     static ObjcType fromCpp(const CppType& m) {
         assert(m.size() <= std::numeric_limits<NSUInteger>::max());
         NSUInteger const count = static_cast<NSUInteger>(m.size());
-        NSUInteger idx = 0;
-        ObjcKeyType __strong keys[count];
-        ObjcValueType __strong objects[count];
+        std::vector<ObjcKeyType> keys;
+        keys.reserve(count);
+        std::vector<ObjcValueType> objects;
+        objects.reserve(count);
         for(const auto& kvp : m) {
-            keys[idx] = Key::Boxed::fromCpp(kvp.first);
-            objects[idx++] = Value::Boxed::fromCpp(kvp.second);
+            keys.push_back(Key::Boxed::fromCpp(kvp.first));
+            objects.push_back(Value::Boxed::fromCpp(kvp.second));
         }
-        return [NSDictionary dictionaryWithObjects:objects forKeys:keys count:count];
+        return [NSDictionary dictionaryWithObjects:objects.data() forKeys:keys.data() count:count];
     }
 };
 

--- a/support-lib/objc/DJIMarshal+Private.h
+++ b/support-lib/objc/DJIMarshal+Private.h
@@ -199,11 +199,14 @@ public:
 
     static ObjcType fromCpp(const CppType& v) {
         assert(v.size() <= std::numeric_limits<NSUInteger>::max());
-        auto array = [NSMutableArray arrayWithCapacity:static_cast<NSUInteger>(v.size())];
+
+        NSUInteger const count = static_cast<NSUInteger>(v.size());
+        NSUInteger idx = 0;
+        EObjcType __strong array[count];
         for(const auto& value : v) {
-            [array addObject:T::Boxed::fromCpp(value)];
+            array[idx++] = T::Boxed::fromCpp(value);
         }
-        return array;
+        return [NSArray arrayWithObjects:array count:count];
     }
 };
 
@@ -229,11 +232,13 @@ public:
 
     static ObjcType fromCpp(const CppType& s) {
         assert(s.size() <= std::numeric_limits<NSUInteger>::max());
-        auto set = [NSMutableSet setWithCapacity:static_cast<NSUInteger>(s.size())];
+        NSUInteger const count = static_cast<NSUInteger>(s.size());
+        NSUInteger idx = 0;
+        EObjcType __strong set[count];
         for(const auto& value : s) {
-            [set addObject:T::Boxed::fromCpp(value)];
+            set[idx++] = T::Boxed::fromCpp(value);
         }
-        return set;
+        return [NSSet setWithObjects:set count:count];;
     }
 };
 
@@ -262,11 +267,15 @@ public:
 
     static ObjcType fromCpp(const CppType& m) {
         assert(m.size() <= std::numeric_limits<NSUInteger>::max());
-        auto map = [NSMutableDictionary dictionaryWithCapacity:static_cast<NSUInteger>(m.size())];
+        NSUInteger const count = static_cast<NSUInteger>(m.size());
+        NSUInteger idx = 0;
+        ObjcKeyType __strong keys[count];
+        ObjcValueType __strong objects[count];
         for(const auto& kvp : m) {
-            [map setObject:Value::Boxed::fromCpp(kvp.second) forKey:Key::Boxed::fromCpp(kvp.first)];
+            keys[idx] = Key::Boxed::fromCpp(kvp.first);
+            objects[idx++] = Value::Boxed::fromCpp(kvp.second);
         }
-        return map;
+        return [NSDictionary dictionaryWithObjects:objects forKeys:keys count:count];
     }
 };
 

--- a/test-suite/generated-src/objc/DBMapDateRecord.mm
+++ b/test-suite/generated-src/objc/DBMapDateRecord.mm
@@ -9,7 +9,7 @@
 - (nonnull instancetype)initWithDatesById:(nonnull NSDictionary *)datesById
 {
     if (self = [super init]) {
-        _datesById = datesById;
+        _datesById = [datesById copy];
     }
     return self;
 }

--- a/test-suite/generated-src/objc/DBMapListRecord.mm
+++ b/test-suite/generated-src/objc/DBMapListRecord.mm
@@ -9,7 +9,7 @@
 - (nonnull instancetype)initWithMapList:(nonnull NSArray *)mapList
 {
     if (self = [super init]) {
-        _mapList = mapList;
+        _mapList = [mapList copy];
     }
     return self;
 }

--- a/test-suite/generated-src/objc/DBMapRecord.mm
+++ b/test-suite/generated-src/objc/DBMapRecord.mm
@@ -10,8 +10,8 @@
                                imap:(nonnull NSDictionary *)imap
 {
     if (self = [super init]) {
-        _map = map;
-        _imap = imap;
+        _map = [map copy];
+        _imap = [imap copy];
     }
     return self;
 }

--- a/test-suite/generated-src/objc/DBNestedCollection.mm
+++ b/test-suite/generated-src/objc/DBNestedCollection.mm
@@ -9,7 +9,7 @@
 - (nonnull instancetype)initWithSetList:(nonnull NSArray *)setList
 {
     if (self = [super init]) {
-        _setList = setList;
+        _setList = [setList copy];
     }
     return self;
 }

--- a/test-suite/generated-src/objc/DBPrimitiveList.mm
+++ b/test-suite/generated-src/objc/DBPrimitiveList.mm
@@ -9,7 +9,7 @@
 - (nonnull instancetype)initWithList:(nonnull NSArray *)list
 {
     if (self = [super init]) {
-        _list = list;
+        _list = [list copy];
     }
     return self;
 }

--- a/test-suite/generated-src/objc/DBSetRecord.mm
+++ b/test-suite/generated-src/objc/DBSetRecord.mm
@@ -10,8 +10,8 @@
                                iset:(nonnull NSSet *)iset
 {
     if (self = [super init]) {
-        _set = set;
-        _iset = iset;
+        _set = [set copy];
+        _iset = [iset copy];
     }
     return self;
 }


### PR DESCRIPTION
This is an alternative approach for https://github.com/dropbox/djinni/pull/123 and https://github.com/dropbox/djinni/pull/124 from @NachoSoto, and I included one commit from him here.

Was playing around with various options, and in the end only using C made things significantly faster.
(VLA arrays are too risky since stack-based and vector only added a barely measurable benefit)

Here's a small, non-scientific benchmark on the iOS 9 Simulator:

```objc
    const size_t runs = 10, elements = 10000000;

    std::vector<NSString *> v;
    for (NSUInteger i = 0; i < elements; i++) {
        v.push_back([NSString stringWithFormat:@"element %tu", i]);
    }

    __block NSArray *oldResult, *newResult;

    uint64_t time_new = dispatch_benchmark(runs, ^{
        id __strong *const array = (id __strong *const)calloc(v.size(), sizeof(id));
        assert(array);
        NSUInteger idx = 0;
        for(const auto& value : v) {
            array[idx++] = value;
        }
        newResult = [NSArray arrayWithObjects:array count:v.size()];
        free(array);
    });
    NSLog(@"new: %f ms", time_new/1e6);

    uint64_t time_old = dispatch_benchmark(runs, ^{
        auto array = [NSMutableArray arrayWithCapacity:static_cast<NSUInteger>(v.size())];
        for(const auto& value : v) {
            [array addObject:value];
        }
        oldResult = [array copy];
    });
    NSLog(@"old: %f ms,", time_old/1e6);
    assert([oldResult isEqualToArray:newResult]);

    // Sprinkle in some CF, just out of curiosity.
    uint64_t time_cf = dispatch_benchmark(runs, ^{
        auto array = CFArrayCreateMutable(nullptr, static_cast<CFIndex>(v.size()), &kCFTypeArrayCallBacks);
        for(const auto& value : v) {
            CFArrayAppendValue(array, (void *)value);
        }
        oldResult = [NSArray arrayWithArray:(__bridge NSArray *)array];
        CFRelease(array);
    });
    NSLog(@"cf: %f ms,", time_cf/1e6);
```

Outputs on my machine:

```
2015-08-13 13:04:46.302 PSPDFCatalog[12832:366832] new: 522.163530 ms
2015-08-13 13:04:54.225 PSPDFCatalog[12832:366832] old: 769.401330 ms,
2015-08-13 13:05:04.047 PSPDFCatalog[12832:366832] cf: 955.982234 ms,
```

So it's about 30% faster, but we end up with a `calloc` in the code. Not sure if that's worth it.