### PR TITLE
Improve Objective-C debug descriptions for record types

### DIFF
--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -385,6 +385,43 @@ class ObjcGenerator(spec: Spec) extends Generator(spec) {
         }
         w.wl
       }
+
+      w.wl("- (NSString *)description")
+      w.braced {
+        w.w(s"return ").nestedN(2) {
+          w.w("[NSString stringWithFormat:@\"<%@ %p")
+
+          for (f <- r.fields) w.w(s" ${idObjc.field(f.ident)}:%@")
+          w.w(">\", self.class, self")
+
+          for (f <- r.fields) {
+            w.w(", ")
+            f.ty.resolved.base match {
+              case MOptional =>
+                f.ty.resolved.args.head.base match {
+                  case df: MDef if df.defType == DEnum =>
+                    w.w(s"@(self.${idObjc.field(f.ident)})")
+                  case _ => w.w(s"self.${idObjc.field(f.ident)}")
+                }
+              case t: MPrimitive => w.w(s"@(self.${idObjc.field(f.ident)})")
+              case df: MDef => df.defType match {
+                case DEnum => w.w(s"@(self.${idObjc.field(f.ident)})")
+                case _ => w.w(s"self.${idObjc.field(f.ident)}")
+              }
+              case e: MExtern =>
+                if (e.objc.pointer) {
+                  w.w(s"self.${idObjc.field(f.ident)}")
+                } else {
+                  w.w(s"@(self.${idObjc.field(f.ident)})")
+                }
+              case _ => w.w(s"self.${idObjc.field(f.ident)}")
+            }
+          }
+        }
+        w.wl("];")
+      }
+      w.wl
+
       w.wl("@end")
     })
   }

--- a/test-suite/generated-src/objc/DBAssortedPrimitives.mm
+++ b/test-suite/generated-src/objc/DBAssortedPrimitives.mm
@@ -112,4 +112,9 @@
             self.oFsixtyfour.hash;
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@ %p b:%@ eight:%@ sixteen:%@ thirtytwo:%@ sixtyfour:%@ fthirtytwo:%@ fsixtyfour:%@ oB:%@ oEight:%@ oSixteen:%@ oThirtytwo:%@ oSixtyfour:%@ oFthirtytwo:%@ oFsixtyfour:%@>", self.class, self, @(self.b), @(self.eight), @(self.sixteen), @(self.thirtytwo), @(self.sixtyfour), @(self.fthirtytwo), @(self.fsixtyfour), self.oB, self.oEight, self.oSixteen, self.oThirtytwo, self.oSixtyfour, self.oFthirtytwo, self.oFsixtyfour];
+}
+
 @end

--- a/test-suite/generated-src/objc/DBClientReturnedRecord.mm
+++ b/test-suite/generated-src/objc/DBClientReturnedRecord.mm
@@ -27,4 +27,9 @@
                                      misc:misc];
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@ %p recordId:%@ content:%@ misc:%@>", self.class, self, @(self.recordId), self.content, self.misc];
+}
+
 @end

--- a/test-suite/generated-src/objc/DBConstants.mm
+++ b/test-suite/generated-src/objc/DBConstants.mm
@@ -48,4 +48,9 @@ DBConstants * __nonnull const DBConstantsObjectConstant = [[DBConstants alloc] i
                                   someString:someString];
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@ %p someInteger:%@ someString:%@>", self.class, self, @(self.someInteger), self.someString];
+}
+
 @end

--- a/test-suite/generated-src/objc/DBDateRecord.mm
+++ b/test-suite/generated-src/objc/DBDateRecord.mm
@@ -44,4 +44,9 @@
     return NSOrderedSame;
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@ %p createdAt:%@>", self.class, self, self.createdAt];
+}
+
 @end

--- a/test-suite/generated-src/objc/DBEmptyRecord.mm
+++ b/test-suite/generated-src/objc/DBEmptyRecord.mm
@@ -18,4 +18,9 @@
     return [[self alloc] init];
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@ %p>", self.class, self];
+}
+
 @end

--- a/test-suite/generated-src/objc/DBExternRecordWithDerivings.mm
+++ b/test-suite/generated-src/objc/DBExternRecordWithDerivings.mm
@@ -60,4 +60,9 @@
     return NSOrderedSame;
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@ %p member:%@ e:%@>", self.class, self, self.member, @(self.e)];
+}
+
 @end

--- a/test-suite/generated-src/objc/DBMapDateRecord.mm
+++ b/test-suite/generated-src/objc/DBMapDateRecord.mm
@@ -19,4 +19,9 @@
     return [[self alloc] initWithDatesById:datesById];
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@ %p datesById:%@>", self.class, self, self.datesById];
+}
+
 @end

--- a/test-suite/generated-src/objc/DBMapListRecord.mm
+++ b/test-suite/generated-src/objc/DBMapListRecord.mm
@@ -19,4 +19,9 @@
     return [[self alloc] initWithMapList:mapList];
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@ %p mapList:%@>", self.class, self, self.mapList];
+}
+
 @end

--- a/test-suite/generated-src/objc/DBMapRecord.mm
+++ b/test-suite/generated-src/objc/DBMapRecord.mm
@@ -23,4 +23,9 @@
                                 imap:imap];
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@ %p map:%@ imap:%@>", self.class, self, self.map, self.imap];
+}
+
 @end

--- a/test-suite/generated-src/objc/DBNestedCollection.mm
+++ b/test-suite/generated-src/objc/DBNestedCollection.mm
@@ -19,4 +19,9 @@
     return [[self alloc] initWithSetList:setList];
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@ %p setList:%@>", self.class, self, self.setList];
+}
+
 @end

--- a/test-suite/generated-src/objc/DBPrimitiveList.mm
+++ b/test-suite/generated-src/objc/DBPrimitiveList.mm
@@ -19,4 +19,9 @@
     return [[self alloc] initWithList:list];
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@ %p list:%@>", self.class, self, self.list];
+}
+
 @end

--- a/test-suite/generated-src/objc/DBRecordWithDerivings.mm
+++ b/test-suite/generated-src/objc/DBRecordWithDerivings.mm
@@ -60,4 +60,9 @@
     return NSOrderedSame;
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@ %p key1:%@ key2:%@>", self.class, self, @(self.key1), self.key2];
+}
+
 @end

--- a/test-suite/generated-src/objc/DBRecordWithDurationAndDerivings.mm
+++ b/test-suite/generated-src/objc/DBRecordWithDurationAndDerivings.mm
@@ -50,4 +50,9 @@
     return NSOrderedSame;
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@ %p dt:%@>", self.class, self, @(self.dt)];
+}
+
 @end

--- a/test-suite/generated-src/objc/DBRecordWithNestedDerivings.mm
+++ b/test-suite/generated-src/objc/DBRecordWithNestedDerivings.mm
@@ -60,4 +60,9 @@
     return NSOrderedSame;
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@ %p key:%@ rec:%@>", self.class, self, @(self.key), self.rec];
+}
+
 @end

--- a/test-suite/generated-src/objc/DBSetRecord.mm
+++ b/test-suite/generated-src/objc/DBSetRecord.mm
@@ -23,4 +23,9 @@
                                 iset:iset];
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@ %p set:%@ iset:%@>", self.class, self, self.set, self.iset];
+}
+
 @end


### PR DESCRIPTION
This is a somewhat crude implementation of `debugDescription` in Objective-C.

We use the trick of boxing all the primitives so emitting the format string is easier.

`debugDescription` is used by lldb when using `po` and makes debugging really really nice.