### PR TITLE
No shadow constructor variables

### DIFF
--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -175,9 +175,9 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
         // Constructor.
         if(r.fields.nonEmpty) {
           w.wl
-          writeAlignedCall(w, actualSelf + "(", r.fields, ")", f => marshal.fieldType(f.ty) + " " + idCpp.local(f.ident))
+          writeAlignedCall(w, actualSelf + "(", r.fields, ")", f => marshal.fieldType(f.ty) + " " + idCpp.local(f.ident) + "_")
           w.wl
-          val init = (f: Field) => idCpp.field(f.ident) + "(std::move(" + idCpp.local(f.ident) + "))"
+          val init = (f: Field) => idCpp.field(f.ident) + "(std::move(" + idCpp.local(f.ident) + "_))"
           w.wl(": " + init(r.fields.head))
           r.fields.tail.map(f => ", " + init(f)).foreach(w.wl)
           w.wl("{}")

--- a/test-suite/generated-src/cpp/assorted_primitives.hpp
+++ b/test-suite/generated-src/cpp/assorted_primitives.hpp
@@ -28,34 +28,34 @@ struct AssortedPrimitives final {
     friend bool operator==(const AssortedPrimitives& lhs, const AssortedPrimitives& rhs);
     friend bool operator!=(const AssortedPrimitives& lhs, const AssortedPrimitives& rhs);
 
-    AssortedPrimitives(bool b,
-                       int8_t eight,
-                       int16_t sixteen,
-                       int32_t thirtytwo,
-                       int64_t sixtyfour,
-                       float fthirtytwo,
-                       double fsixtyfour,
-                       std::experimental::optional<bool> o_b,
-                       std::experimental::optional<int8_t> o_eight,
-                       std::experimental::optional<int16_t> o_sixteen,
-                       std::experimental::optional<int32_t> o_thirtytwo,
-                       std::experimental::optional<int64_t> o_sixtyfour,
-                       std::experimental::optional<float> o_fthirtytwo,
-                       std::experimental::optional<double> o_fsixtyfour)
-    : b(std::move(b))
-    , eight(std::move(eight))
-    , sixteen(std::move(sixteen))
-    , thirtytwo(std::move(thirtytwo))
-    , sixtyfour(std::move(sixtyfour))
-    , fthirtytwo(std::move(fthirtytwo))
-    , fsixtyfour(std::move(fsixtyfour))
-    , o_b(std::move(o_b))
-    , o_eight(std::move(o_eight))
-    , o_sixteen(std::move(o_sixteen))
-    , o_thirtytwo(std::move(o_thirtytwo))
-    , o_sixtyfour(std::move(o_sixtyfour))
-    , o_fthirtytwo(std::move(o_fthirtytwo))
-    , o_fsixtyfour(std::move(o_fsixtyfour))
+    AssortedPrimitives(bool b_,
+                       int8_t eight_,
+                       int16_t sixteen_,
+                       int32_t thirtytwo_,
+                       int64_t sixtyfour_,
+                       float fthirtytwo_,
+                       double fsixtyfour_,
+                       std::experimental::optional<bool> o_b_,
+                       std::experimental::optional<int8_t> o_eight_,
+                       std::experimental::optional<int16_t> o_sixteen_,
+                       std::experimental::optional<int32_t> o_thirtytwo_,
+                       std::experimental::optional<int64_t> o_sixtyfour_,
+                       std::experimental::optional<float> o_fthirtytwo_,
+                       std::experimental::optional<double> o_fsixtyfour_)
+    : b(std::move(b_))
+    , eight(std::move(eight_))
+    , sixteen(std::move(sixteen_))
+    , thirtytwo(std::move(thirtytwo_))
+    , sixtyfour(std::move(sixtyfour_))
+    , fthirtytwo(std::move(fthirtytwo_))
+    , fsixtyfour(std::move(fsixtyfour_))
+    , o_b(std::move(o_b_))
+    , o_eight(std::move(o_eight_))
+    , o_sixteen(std::move(o_sixteen_))
+    , o_thirtytwo(std::move(o_thirtytwo_))
+    , o_sixtyfour(std::move(o_sixtyfour_))
+    , o_fthirtytwo(std::move(o_fthirtytwo_))
+    , o_fsixtyfour(std::move(o_fsixtyfour_))
     {}
 };
 

--- a/test-suite/generated-src/cpp/client_returned_record.hpp
+++ b/test-suite/generated-src/cpp/client_returned_record.hpp
@@ -16,12 +16,12 @@ struct ClientReturnedRecord final {
     std::string content;
     std::experimental::optional<std::string> misc;
 
-    ClientReturnedRecord(int64_t record_id,
-                         std::string content,
-                         std::experimental::optional<std::string> misc)
-    : record_id(std::move(record_id))
-    , content(std::move(content))
-    , misc(std::move(misc))
+    ClientReturnedRecord(int64_t record_id_,
+                         std::string content_,
+                         std::experimental::optional<std::string> misc_)
+    : record_id(std::move(record_id_))
+    , content(std::move(content_))
+    , misc(std::move(misc_))
     {}
 };
 

--- a/test-suite/generated-src/cpp/constants.hpp
+++ b/test-suite/generated-src/cpp/constants.hpp
@@ -41,10 +41,10 @@ struct Constants final {
     int32_t some_integer;
     std::string some_string;
 
-    Constants(int32_t some_integer,
-              std::string some_string)
-    : some_integer(std::move(some_integer))
-    , some_string(std::move(some_string))
+    Constants(int32_t some_integer_,
+              std::string some_string_)
+    : some_integer(std::move(some_integer_))
+    , some_string(std::move(some_string_))
     {}
 };
 

--- a/test-suite/generated-src/cpp/date_record.hpp
+++ b/test-suite/generated-src/cpp/date_record.hpp
@@ -20,8 +20,8 @@ struct DateRecord final {
     friend bool operator<=(const DateRecord& lhs, const DateRecord& rhs);
     friend bool operator>=(const DateRecord& lhs, const DateRecord& rhs);
 
-    DateRecord(std::chrono::system_clock::time_point created_at)
-    : created_at(std::move(created_at))
+    DateRecord(std::chrono::system_clock::time_point created_at_)
+    : created_at(std::move(created_at_))
     {}
 };
 

--- a/test-suite/generated-src/cpp/extern_record_with_derivings.hpp
+++ b/test-suite/generated-src/cpp/extern_record_with_derivings.hpp
@@ -21,9 +21,9 @@ struct ExternRecordWithDerivings final {
     friend bool operator<=(const ExternRecordWithDerivings& lhs, const ExternRecordWithDerivings& rhs);
     friend bool operator>=(const ExternRecordWithDerivings& lhs, const ExternRecordWithDerivings& rhs);
 
-    ExternRecordWithDerivings(::testsuite::RecordWithDerivings member,
-                              ::testsuite::color e)
-    : member(std::move(member))
-    , e(std::move(e))
+    ExternRecordWithDerivings(::testsuite::RecordWithDerivings member_,
+                              ::testsuite::color e_)
+    : member(std::move(member_))
+    , e(std::move(e_))
     {}
 };

--- a/test-suite/generated-src/cpp/map_date_record.hpp
+++ b/test-suite/generated-src/cpp/map_date_record.hpp
@@ -13,8 +13,8 @@ namespace testsuite {
 struct MapDateRecord final {
     std::unordered_map<std::string, std::chrono::system_clock::time_point> dates_by_id;
 
-    MapDateRecord(std::unordered_map<std::string, std::chrono::system_clock::time_point> dates_by_id)
-    : dates_by_id(std::move(dates_by_id))
+    MapDateRecord(std::unordered_map<std::string, std::chrono::system_clock::time_point> dates_by_id_)
+    : dates_by_id(std::move(dates_by_id_))
     {}
 };
 

--- a/test-suite/generated-src/cpp/map_list_record.hpp
+++ b/test-suite/generated-src/cpp/map_list_record.hpp
@@ -14,8 +14,8 @@ namespace testsuite {
 struct MapListRecord final {
     std::vector<std::unordered_map<std::string, int64_t>> map_list;
 
-    MapListRecord(std::vector<std::unordered_map<std::string, int64_t>> map_list)
-    : map_list(std::move(map_list))
+    MapListRecord(std::vector<std::unordered_map<std::string, int64_t>> map_list_)
+    : map_list(std::move(map_list_))
     {}
 };
 

--- a/test-suite/generated-src/cpp/map_record.hpp
+++ b/test-suite/generated-src/cpp/map_record.hpp
@@ -14,10 +14,10 @@ struct MapRecord final {
     std::unordered_map<std::string, int64_t> map;
     std::unordered_map<int32_t, int32_t> imap;
 
-    MapRecord(std::unordered_map<std::string, int64_t> map,
-              std::unordered_map<int32_t, int32_t> imap)
-    : map(std::move(map))
-    , imap(std::move(imap))
+    MapRecord(std::unordered_map<std::string, int64_t> map_,
+              std::unordered_map<int32_t, int32_t> imap_)
+    : map(std::move(map_))
+    , imap(std::move(imap_))
     {}
 };
 

--- a/test-suite/generated-src/cpp/nested_collection.hpp
+++ b/test-suite/generated-src/cpp/nested_collection.hpp
@@ -13,8 +13,8 @@ namespace testsuite {
 struct NestedCollection final {
     std::vector<std::unordered_set<std::string>> set_list;
 
-    NestedCollection(std::vector<std::unordered_set<std::string>> set_list)
-    : set_list(std::move(set_list))
+    NestedCollection(std::vector<std::unordered_set<std::string>> set_list_)
+    : set_list(std::move(set_list_))
     {}
 };
 

--- a/test-suite/generated-src/cpp/primitive_list.hpp
+++ b/test-suite/generated-src/cpp/primitive_list.hpp
@@ -12,8 +12,8 @@ namespace testsuite {
 struct PrimitiveList final {
     std::vector<int64_t> list;
 
-    PrimitiveList(std::vector<int64_t> list)
-    : list(std::move(list))
+    PrimitiveList(std::vector<int64_t> list_)
+    : list(std::move(list_))
     {}
 };
 

--- a/test-suite/generated-src/cpp/record_with_derivings.hpp
+++ b/test-suite/generated-src/cpp/record_with_derivings.hpp
@@ -22,10 +22,10 @@ struct RecordWithDerivings final {
     friend bool operator<=(const RecordWithDerivings& lhs, const RecordWithDerivings& rhs);
     friend bool operator>=(const RecordWithDerivings& lhs, const RecordWithDerivings& rhs);
 
-    RecordWithDerivings(int32_t key1,
-                        std::string key2)
-    : key1(std::move(key1))
-    , key2(std::move(key2))
+    RecordWithDerivings(int32_t key1_,
+                        std::string key2_)
+    : key1(std::move(key1_))
+    , key2(std::move(key2_))
     {}
 };
 

--- a/test-suite/generated-src/cpp/record_with_duration_and_derivings.hpp
+++ b/test-suite/generated-src/cpp/record_with_duration_and_derivings.hpp
@@ -20,8 +20,8 @@ struct RecordWithDurationAndDerivings final {
     friend bool operator<=(const RecordWithDurationAndDerivings& lhs, const RecordWithDurationAndDerivings& rhs);
     friend bool operator>=(const RecordWithDurationAndDerivings& lhs, const RecordWithDurationAndDerivings& rhs);
 
-    RecordWithDurationAndDerivings(std::chrono::duration<double, std::nano> dt)
-    : dt(std::move(dt))
+    RecordWithDurationAndDerivings(std::chrono::duration<double, std::nano> dt_)
+    : dt(std::move(dt_))
     {}
 };
 

--- a/test-suite/generated-src/cpp/record_with_nested_derivings.hpp
+++ b/test-suite/generated-src/cpp/record_with_nested_derivings.hpp
@@ -22,10 +22,10 @@ struct RecordWithNestedDerivings final {
     friend bool operator<=(const RecordWithNestedDerivings& lhs, const RecordWithNestedDerivings& rhs);
     friend bool operator>=(const RecordWithNestedDerivings& lhs, const RecordWithNestedDerivings& rhs);
 
-    RecordWithNestedDerivings(int32_t key,
-                              RecordWithDerivings rec)
-    : key(std::move(key))
-    , rec(std::move(rec))
+    RecordWithNestedDerivings(int32_t key_,
+                              RecordWithDerivings rec_)
+    : key(std::move(key_))
+    , rec(std::move(rec_))
     {}
 };
 

--- a/test-suite/generated-src/cpp/set_record.hpp
+++ b/test-suite/generated-src/cpp/set_record.hpp
@@ -14,10 +14,10 @@ struct SetRecord final {
     std::unordered_set<std::string> set;
     std::unordered_set<int32_t> iset;
 
-    SetRecord(std::unordered_set<std::string> set,
-              std::unordered_set<int32_t> iset)
-    : set(std::move(set))
-    , iset(std::move(iset))
+    SetRecord(std::unordered_set<std::string> set_,
+              std::unordered_set<int32_t> iset_)
+    : set(std::move(set_))
+    , iset(std::move(iset_))
     {}
 };
 


### PR DESCRIPTION
adds a _ before variable names to prevent a warning.

Clang emits “Declaration shadows a field of …” when using the same variable name in the constructor. I googled a bit but couldn’t find a best practice besides `new_` which seems excessive long, so I settled with just an underscore.

Before:
<img width="591" alt="screen shot 2015-08-15 at 01 08 39" src="https://cloud.githubusercontent.com/assets/58493/9285824/3487bc32-42ea-11e5-888e-c00c9f351546.png">

After:
<img width="380" alt="screen shot 2015-08-15 at 01 10 36" src="https://cloud.githubusercontent.com/assets/58493/9285852/777194dc-42ea-11e5-8eb5-f9a521cfcf1e.png">

