### PR TITLE
modify libtextsort.gyp to add ".h .hpp" file to generated project

### DIFF
--- a/example/libtextsort.gyp
+++ b/example/libtextsort.gyp
@@ -9,9 +9,9 @@
             "ldflags": [ "-llog", "-Wl,--build-id,--gc-sections,--exclude-libs,ALL" ],
             "sources": [
               "../support-lib/jni/djinni_main.cpp",
-              "<!@(python glob.py generated-src/jni   '*.cpp')",
-              "<!@(python glob.py generated-src/cpp   '*.cpp')",
-              "<!@(python glob.py handwritten-src/cpp '*.cpp')",
+              "<!@(python glob.py generated-src/jni   '*.h' '*.hpp' '*.cpp')",
+              "<!@(python glob.py generated-src/cpp   '*.h' '*.hpp' '*.cpp')",
+              "<!@(python glob.py handwritten-src/cpp '*.h' '*.hpp' '*.cpp')",
             ],
             "include_dirs": [
               "generated-src/jni",
@@ -27,9 +27,9 @@
               "../support-lib/support_lib.gyp:djinni_objc",
             ],
             "sources": [
-              "<!@(python glob.py generated-src/objc  '*.cpp' '*.mm' '*.m')",
-              "<!@(python glob.py generated-src/cpp   '*.cpp')",
-              "<!@(python glob.py handwritten-src/cpp '*.cpp')",
+              "<!@(python glob.py generated-src/objc  '*.h' '*.hpp' '*.cpp' '*.mm' '*.m')",
+              "<!@(python glob.py generated-src/cpp   '*.h' '*.hpp' '*.cpp')",
+              "<!@(python glob.py handwritten-src/cpp '*.h' '*.hpp' '*.cpp')",
             ],
             "include_dirs": [
               "generated-src/objc",

--- a/support-lib/support_lib.gyp
+++ b/support-lib/support_lib.gyp
@@ -4,7 +4,8 @@
             "target_name": "djinni_jni",
             "type": "static_library",
             "sources": [
-              "jni/djinni_support.cpp",
+                "<!@(ls jni/*)" ,
+                #"jni/djinni_support.cpp",
             ],
             "include_dirs": [
               "jni",
@@ -22,8 +23,10 @@
               "CLANG_ENABLE_OBJC_ARC": "YES",
             },
             "sources": [
-              "objc/DJIWeakPtrWrapper.mm",
-              "objc/DJIError.mm",
+              "<!@(dir=('objc'); \
+              pattern=('*.h' '*.hpp' '*.cpp' '*.mm' '*.m'); \
+              echo ${pattern[@]} | xargs -n 1 find ${dir[@]} -iname \
+              )", 
             ],
             "include_dirs": [
               "objc",


### PR DESCRIPTION
Generated header files are not included in generated project file, but we often need to scan code in header files when we finish project.