### PR TITLE
updated Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ clean:
 	-rm -rf obj/
 	-rm -rf build/
 	-rm -rf build_ios/
-	-rm GypAndroid.mk
+	-rm -f GypAndroid.mk
 
 # rule to lazily clone gyp
 # freeze gyp at the last version with android support


### PR DESCRIPTION
It could happen that the file `GypAndroid.mk` does not exist (as an example, after a `make djinni`), thus the consequent `make clean` fails because in the Makefile a `-f` parameter is missed.