### PR TITLE
improved specialized hash function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 .DS_Store
 
+# QtCreator stuff
+*.config
+*.creator
+*.creator.user
+*.includes
+
 **/.idea/workspace.xml
 **/.idea/tasks.xml
 

--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -54,11 +54,12 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
     val self = marshal.typename(ident, e)
 
     if (spec.cppEnumHashWorkaround) {
+      refs.hpp.add("#include <type_traits>") // needed for std::underlying_type
       refs.hpp.add("#include <functional>") // needed for std::hash
     }
 
     writeHppFile(ident, origin, refs.hpp, refs.hppFwds, w => {
-      w.w(s"enum class $self : int").bracedSemi {
+      w.w(s"enum class $self : unsigned int").bracedSemi {
         for (o <- e.options) {
           writeDoc(w, o.doc)
           w.wl(idCpp.enum(o.ident.name) + ",")
@@ -74,8 +75,9 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
           (w: IndentWriter) => {
             w.wl("template <>")
             w.w(s"struct hash<$fqSelf>").bracedSemi {
-              w.w(s"size_t operator()($fqSelf type) const").braced {
-                w.wl("return std::hash<int>()(static_cast<int>(type));")
+              w.wl(s"using underlying_type = typename std::underlying_type<$fqSelf>::type;")
+              w.w(s"std::size_t operator()(const $fqSelf &type) const").braced {
+                w.wl("return std::hash<underlying_type>()(static_cast<underlying_type>(type));")
               }
             }
           }


### PR DESCRIPTION
The specializations for the function `std::hash` due to the generated `enum`s are difficult to maintain, for updating the underlying type requires several changes to the file `CppGenerator.scala`; moreover, it's not possible to let the users to declare their own underlying types as long as the latter are hardcoded in the generated functions (that would be a good feature indeed, so why not look forward to it?).
The patch introduces `std::underlying_type` to free the generated functions from the actual underlying types of the `enum`s.
To include `type_traits` is mandatory to use `std::underlying_type`.
In addition, the default type for `enum`s has been changed to `unsigned int`, for it looks more suitable to the way `djinni` uses those `enum`s.

The file `.gitignore` has been updated to exclude any file generated by qtcreator.
It would help having those line in that file for future contributions. Thank you.