### PR TITLE
Support for printing descriptions of non NSObject external types

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ objc:
     boxed: 'MLBRecord1'
     pointer: true
     hash: '%s.hash'
+    printDescription: '%s'
 objcpp:
     translator: '::mylib::djinni::objc::Record1'
     header: '"mylib/djinni/objc/Record1.hpp"'

--- a/example/example.yaml
+++ b/example/example.yaml
@@ -38,6 +38,10 @@ objc:
   # If the type is a "record" and has "eq" deriving then this string must not be empty.
   # It declares a well-formed expression with a single "%s" format placeholder replaced with the variable for which the hash code is needed
   hash: '%s.hash'
+  # Specifies how a description of this type can be printed.
+  # If the type is NOT a subclass of NSObject, this needs to be modified to return a NSObject.
+  # For example, if the type is a CGRect, use `NSStringFromCGRect(%s)`. If the type is a NSInteger, use `@(%s)`.
+  printDescription: '%s'
 objcpp:
   # The fully qualified name of the class containing the toCpp/fromCpp methods.
   translator: '::mylib::djinni::objc::Record1'

--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -403,12 +403,7 @@ class ObjcGenerator(spec: Spec) extends Generator(spec) {
                 case DEnum => w.w(s"@(self.${idObjc.field(f.ident)})")
                 case _ => w.w(s"self.${idObjc.field(f.ident)}")
               }
-              case e: MExtern =>
-                if (e.objc.pointer) {
-                  w.w(s"self.${idObjc.field(f.ident)}")
-                } else {
-                  w.w(s"@(self.${idObjc.field(f.ident)})")
-                }
+              case e: MExtern => w.w(e.objc.printDescription.format("self." + idObjc.field(f.ident)))
               case _ => w.w(s"self.${idObjc.field(f.ident)}")
             }
           }

--- a/src/source/ObjcMarshal.scala
+++ b/src/source/ObjcMarshal.scala
@@ -88,6 +88,11 @@ class ObjcMarshal(spec: Spec) extends Marshal(spec) {
     case e: Enum => "NSNumber"
   }
 
+  def printDescription(td: TypeDecl) = td.body match {
+    case e: Enum => "@(%s)"
+    case _ => "%s"
+  }
+
   // Return value: (Type_Name, Is_Class_Or_Not)
   def toObjcType(ty: TypeRef): (String, Boolean) = toObjcType(ty.resolved, false)
   def toObjcType(ty: TypeRef, needRef: Boolean): (String, Boolean) = toObjcType(ty.resolved, needRef)

--- a/src/source/YamlGenerator.scala
+++ b/src/source/YamlGenerator.scala
@@ -121,7 +121,8 @@ class YamlGenerator(spec: Spec) extends Generator(spec) {
     "header" -> QuotedString(objcMarshal.include(td.ident)),
     "boxed" -> QuotedString(objcMarshal.boxedTypename(td)),
     "pointer" -> objcMarshal.isPointer(td),
-    "hash" -> QuotedString("%s.hash")
+    "hash" -> QuotedString("%s.hash"),
+    "printDescription" -> QuotedString(objcMarshal.printDescription(td))
   )
 
   private def objcpp(td: TypeDecl) = Map[String, Any](
@@ -195,7 +196,8 @@ object YamlGenerator {
       nested(td, "objc")("header").toString,
       nested(td, "objc")("boxed").toString,
       nested(td, "objc")("pointer").asInstanceOf[Boolean],
-      nested(td, "objc")("hash").toString),
+      nested(td, "objc")("hash").toString,
+      nested(td, "objc")("printDescription").toString),
     MExtern.Objcpp(
       nested(td, "objcpp")("translator").toString,
       nested(td, "objcpp")("header").toString),

--- a/src/source/meta.scala
+++ b/src/source/meta.scala
@@ -46,7 +46,8 @@ object MExtern {
     header: String,
     boxed: String, // Fully qualified Objective-C typename, must be an object. Only used for "record" types.
     pointer: Boolean, // True to construct pointer types and make it eligible for "nonnull" qualifier. Only used for "record" types.
-    hash: String // A well-formed expression to get the hash value. Must be a format string with a single "%s" placeholder. Only used for "record" types with "eq" deriving when needed.
+    hash: String, // A well-formed expression to get the hash value. Must be a format string with a single "%s" placeholder. Only used for "record" types with "eq" deriving when needed
+    printDescription: String // Specified how to print out a description for the type. Useful if the type isn't a NSObject, but for example a CGRect.
   )
   case class Objcpp(
     translator: String, // C++ typename containing toCpp/fromCpp methods

--- a/test-suite/djinni/date.yaml
+++ b/test-suite/djinni/date.yaml
@@ -14,6 +14,7 @@ objc:
   boxed: 'NSDate'
   pointer: true
   hash: '(NSUInteger)%s.timeIntervalSinceReferenceDate'
+  printDescription: '%s'
 objcpp:
   translator: '::djinni::Date'
   header: '"DJIMarshal+Private.h"'

--- a/test-suite/djinni/duration.yaml
+++ b/test-suite/djinni/duration.yaml
@@ -17,6 +17,7 @@ objc:
   boxed: 'NSNumber'
   pointer: false
   hash: '(NSUInteger)%s'
+  printDescription: '@(%s)'
 objcpp:
   translator: '::djinni::Duration'
   header: '"Duration-objc.hpp"'
@@ -46,6 +47,7 @@ objc:
   boxed: 'NSNumber'
   pointer: false
   hash: ''
+  printDescription: '@(%s)'
 objcpp:
   translator: '::djinni::Duration_h'
   header: '"Duration-objc.hpp"'
@@ -75,6 +77,7 @@ objc:
   boxed: 'NSNumber'
   pointer: false
   hash: ''
+  printDescription: '@(%s)'
 objcpp:
   translator: '::djinni::Duration_min'
   header: '"Duration-objc.hpp"'
@@ -104,6 +107,7 @@ objc:
   boxed: 'NSNumber'
   pointer: false
   hash: ''
+  printDescription: '@(%s)'
 objcpp:
   translator: '::djinni::Duration_s'
   header: '"Duration-objc.hpp"'
@@ -133,6 +137,7 @@ objc:
   boxed: 'NSNumber'
   pointer: false
   hash: ''
+  printDescription: '@(%s)'
 objcpp:
   translator: '::djinni::Duration_ms'
   header: '"Duration-objc.hpp"'
@@ -162,6 +167,7 @@ objc:
   boxed: 'NSNumber'
   pointer: false
   hash: ''
+  printDescription: '@(%s)'
 objcpp:
   translator: '::djinni::Duration_us'
   header: '"Duration-objc.hpp"'
@@ -191,6 +197,7 @@ objc:
   boxed: 'NSNumber'
   pointer: false
   hash: ''
+  printDescription: '@(%s)'
 objcpp:
   translator: '::djinni::Duration_ns'
   header: '"Duration-objc.hpp"'


### PR DESCRIPTION
This allows specifying how the description of a external type should be printed.

We wanted to bridge a type to `CGRect`, but ran into the problem of printing the containing types description. A `CGRect`, or any other non NSObject type, can't be printed using `%@` but has to be converted into a `NSObject` first. With this patch, you can simply specify that in the yaml file:

```
   printDescription: 'NSStringFromCGRect(%s)'
```
