### PR TITLE
Some patches for djinni veterans

### DIFF
--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -1,8 +1,8 @@
-.PHONY: all objc java linux
+.PHONY: all objc java linux_docker
 
 FORCE_DJINNI := $(shell ./run_djinni.sh >&2)
 
-all: objc java linux
+all: objc java
 
 objc:
 	cd objc; xcodebuild -sdk iphonesimulator -project DjinniObjcTest.xcodeproj -scheme DjinniObjcTest test
@@ -10,5 +10,5 @@ objc:
 java:
 	cd java && ant compile test
 
-linux:
+linux_docker:
 	cd ..; ./test-suite/java/docker/run_dockerized_test.sh

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -18,4 +18,5 @@ You may need to have Xcode open for the simulator portion of the objc
 tests to complete successfully.  Try opening the app if you see a
 failure connecting to the simulator.
 
-To test Java generated code in linux environments, run `make linux`.
+To test Java generated code in linux environments (via Docker), run `make linux`.
+FMI see [Docker testing instructions](java/docker/README.md).

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -18,5 +18,8 @@ You may need to have Xcode open for the simulator portion of the objc
 tests to complete successfully.  Try opening the app if you see a
 failure connecting to the simulator.
 
-To test Java generated code in linux environments (via Docker), run `make linux`.
-FMI see [Docker testing instructions](java/docker/README.md).
+Testing in Linux (via Docker)
+-----------------------------
+To test Java generated code in a variety of linux environments (via Docker),
+run `make linux_docker`.  FMI see 
+[Docker-based testing instructions](java/docker/README.md).

--- a/test-suite/java/build.xml
+++ b/test-suite/java/build.xml
@@ -2,7 +2,23 @@
 <project name="Djinni-test">
   <target name="compile">
     <mkdir dir="build"/>
-	<mkdir dir="build/local"/>
+	  <mkdir dir="build/local"/>
+
+	  <!-- Veteran djinni users might not have cmake.  Given them some advice. -->
+    <property environment="env" />
+    <fail
+      message="****${line.separator}
+               Can't find cmake!  Please install, using e.g.:${line.separator}
+                 $ brew install cmake ${line.separator}
+                 $ sudo port install cmake ${line.separator}
+                 $ apt-get install cmake ${line.separator}
+                 $ yum install cmake ${line.separator}
+               ****${line.separator}">
+      <condition>
+        <not><available file="cmake"  filepath="${env.PATH}" /></not>
+      </condition>
+    </fail>
+
     <exec executable="cmake" failonerror="true" dir="build">
       <!-- Verbose helps make debugging compiler issues easier -->
       <arg value="-DCMAKE_VERBOSE_MAKEFILE=ON"/>

--- a/test-suite/java/docker/README.md
+++ b/test-suite/java/docker/README.md
@@ -2,7 +2,7 @@ Djinni Linux Tests
 ------------------
 
 This directory contains a suite of tools for testing djinni (JNI only)
-on Linux.  The suite helps ensure the portability of djinni and 
+on Linux via Docker.  The suite helps ensure the portability of djinni and 
 (self-)document compatible platforms.
 
 Quickstart


### PR DESCRIPTION
This change:
 * Prints a nice error message if the user is missing cmake.  I tested it by running the build in docker with `cmake` removed
 * Moves the docker tests out of the `all` target for the test suite.  I checked they still work by running `make linux_docker`.
 * Patches docs in a couple of places to make the Docker dependency easier to find.

In response to discussion at: https://github.com/dropbox/djinni/pull/140#issuecomment-155940221

✓ I have previously signed the Dropbox CLA