### PR TITLE
Forward declare instead of #include enums/records from interface's hpp

### DIFF
--- a/example/generated-src/cpp/sort_items.hpp
+++ b/example/generated-src/cpp/sort_items.hpp
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include "item_list.hpp"
-#include "sort_order.hpp"
 #include <memory>
 
 namespace textsort {
 
 class TextboxListener;
+enum class sort_order;
+struct ItemList;
 
 class SortItems {
 public:

--- a/example/generated-src/cpp/textbox_listener.hpp
+++ b/example/generated-src/cpp/textbox_listener.hpp
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include "item_list.hpp"
-
 namespace textsort {
+
+struct ItemList;
 
 class TextboxListener {
 public:

--- a/example/generated-src/objc/TXSItemList.mm
+++ b/example/generated-src/objc/TXSItemList.mm
@@ -9,7 +9,7 @@
 - (nonnull instancetype)initWithItems:(nonnull NSArray<NSString *> *)items
 {
     if (self = [super init]) {
-        _items = items;
+        _items = [items copy];
     }
     return self;
 }

--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -37,12 +37,12 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
     var hppFwds = mutable.TreeSet[String]()
     var cpp = mutable.TreeSet[String]()
 
-    def find(ty: TypeRef) { find(ty.resolved) }
-    def find(tm: MExpr) {
-      tm.args.foreach(find)
-      find(tm.base)
+    def find(ty: TypeRef, forwardDeclareOnly: Boolean) { find(ty.resolved, forwardDeclareOnly) }
+    def find(tm: MExpr, forwardDeclareOnly: Boolean) {
+      tm.args.foreach((x) => find(x, forwardDeclareOnly))
+      find(tm.base, forwardDeclareOnly)
     }
-    def find(m: Meta) = for(r <- marshal.references(m, name)) r match {
+    def find(m: Meta, forwardDeclareOnly : Boolean) = for(r <- marshal.references(m, name, forwardDeclareOnly)) r match {
       case ImportRef(arg) => hpp.add("#include " + arg)
       case DeclRef(decl, Some(spec.cppNamespace)) => hppFwds.add(decl)
       case DeclRef(_, _) =>
@@ -130,8 +130,8 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
 
   override def generateRecord(origin: String, ident: Ident, doc: Doc, params: Seq[TypeParam], r: Record) {
     val refs = new CppRefs(ident.name)
-    r.fields.foreach(f => refs.find(f.ty))
-    r.consts.foreach(c => refs.find(c.ty))
+    r.fields.foreach(f => refs.find(f.ty, false))
+    r.consts.foreach(c => refs.find(c.ty, false))
     refs.hpp.add("#include <utility>") // Add for std::move
 
     val self = marshal.typename(ident, r)
@@ -255,11 +255,11 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
   override def generateInterface(origin: String, ident: Ident, doc: Doc, typeParams: Seq[TypeParam], i: Interface) {
     val refs = new CppRefs(ident.name)
     i.methods.map(m => {
-      m.params.map(p => refs.find(p.ty))
-      m.ret.foreach(refs.find)
+      m.params.map(p => refs.find(p.ty, true))
+      m.ret.foreach((x)=>refs.find(x, true))
     })
     i.consts.map(c => {
-      refs.find(c.ty)
+      refs.find(c.ty, true)
     })
 
     val self = marshal.typename(ident, i)

--- a/src/source/CppMarshal.scala
+++ b/src/source/CppMarshal.scala
@@ -32,7 +32,7 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
   override def toCpp(tm: MExpr, expr: String): String = throw new AssertionError("cpp to cpp conversion")
   override def fromCpp(tm: MExpr, expr: String): String = throw new AssertionError("cpp to cpp conversion")
 
-  def references(m: Meta, exclude: String): Seq[SymbolReference] = m match {
+  def references(m: Meta, exclude: String, forwardDeclareOnly: Boolean): Seq[SymbolReference] = m match {
     case p: MPrimitive => p.idlName match {
       case "i8" | "i16" | "i32" | "i64" => List(ImportRef("<cstdint>"))
       case _ => List()
@@ -45,9 +45,23 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
     case MSet => List(ImportRef("<unordered_set>"))
     case MMap => List(ImportRef("<unordered_map>"))
     case d: MDef => d.defType match {
-      case DEnum | DRecord =>
+      case DRecord =>
         if (d.name != exclude) {
-          List(ImportRef(include(d.name)))
+          if (forwardDeclareOnly) {
+            List(DeclRef(s"struct ${typename(d.name, d.body)};", Some(spec.cppNamespace)))
+          } else {
+            List(ImportRef(include(d.name)))
+          }
+        } else {
+          List()
+        }
+      case DEnum =>
+        if (d.name != exclude) {
+          if (forwardDeclareOnly) {
+            List(DeclRef(s"enum class ${typename(d.name, d.body)};", Some(spec.cppNamespace)))
+          } else {
+            List(ImportRef(include(d.name)))
+          }
         } else {
           List()
         }

--- a/test-suite/generated-src/cpp/client_interface.hpp
+++ b/test-suite/generated-src/cpp/client_interface.hpp
@@ -3,13 +3,14 @@
 
 #pragma once
 
-#include "client_returned_record.hpp"
 #include <cstdint>
 #include <experimental/optional>
 #include <string>
 #include <vector>
 
 namespace testsuite {
+
+struct ClientReturnedRecord;
 
 /** Client interface */
 class ClientInterface {

--- a/test-suite/generated-src/cpp/extern_interface_2.hpp
+++ b/test-suite/generated-src/cpp/extern_interface_2.hpp
@@ -3,9 +3,10 @@
 
 #pragma once
 
-#include "extern_record_with_derivings.hpp"
 #include "test_helpers.hpp"
 #include <memory>
+
+struct ExternRecordWithDerivings;
 
 class ExternInterface2 {
 public:

--- a/test-suite/generated-src/cpp/test_helpers.hpp
+++ b/test-suite/generated-src/cpp/test_helpers.hpp
@@ -3,12 +3,6 @@
 
 #pragma once
 
-#include "assorted_primitives.hpp"
-#include "color.hpp"
-#include "map_list_record.hpp"
-#include "nested_collection.hpp"
-#include "primitive_list.hpp"
-#include "set_record.hpp"
 #include <cstdint>
 #include <experimental/optional>
 #include <memory>
@@ -20,6 +14,12 @@ namespace testsuite {
 
 class ClientInterface;
 class UserToken;
+enum class color;
+struct AssortedPrimitives;
+struct MapListRecord;
+struct NestedCollection;
+struct PrimitiveList;
+struct SetRecord;
 
 /**
  * Helper methods used by various different tests.

--- a/test-suite/handwritten-src/cpp/test_helpers.cpp
+++ b/test-suite/handwritten-src/cpp/test_helpers.cpp
@@ -2,6 +2,12 @@
 #include "client_returned_record.hpp"
 #include "client_interface.hpp"
 #include "user_token.hpp"
+#include "assorted_primitives.hpp"
+#include "color.hpp"
+#include "map_list_record.hpp"
+#include "nested_collection.hpp"
+#include "primitive_list.hpp"
+#include "set_record.hpp"
 #include <exception>
 
 namespace testsuite {


### PR DESCRIPTION
Fixes #165.

Not tested except of on one sample project mentioned in #164.

---

Note that I never [seriously] learned Scala, also I'm not too familiar with Djinni itself, so don't expect the pull request be a quality one.