### PR TITLE
Support lib: target Java 7, not 8

### DIFF
--- a/test-suite/java/build.xml
+++ b/test-suite/java/build.xml
@@ -35,7 +35,7 @@
 	  <arg value="install"/>
 	</exec>
     <mkdir dir="build/classes"/>
-    <javac destdir="build/classes" includeantruntime="false" encoding="UTF-8" debug="on">
+    <javac destdir="build/classes" includeantruntime="false" encoding="UTF-8" debug="on" target="1.7" source="1.7">
       <classpath>
         <fileset dir="../../deps/java/"><include name="*.jar"/></fileset>
         <fileset dir="../../deps/java/test"><include name="*.jar"/></fileset>


### PR DESCRIPTION
Avoid using Java 8 features in NativeLibLoader, and add compile checks to keep us at 1.7 (at least for now).

@pwais, can you confirm that this works for you? I think it's identical -- we were passing 1 for `maxDepth` to `Files.walk`, so replacing it with list-one-directory calls should be equivalent, but please check.

More generally, there's a question of which version of Java we should be targeting. On the C++ and ObjC sides, Djinni is aggressive in using the very latest. On the Java side, given the state of Java 8 on Android, I think it's worth being more conservative for now. The changes needed to go back to 7 here aren't extensive or particularly painful. If they were, or if at any point in the future we stand to gain a lot from requiring Java 8, then we should definitely do so. (But when we do, we should enforce that in the build system et al, so that trying to build with 7 results in clear errors rather than small breakage.)