### PR TITLE
Change base ubuntu version in Dockerfile from utopic to vivid

### DIFF
--- a/example/localhost/Dockerfile
+++ b/example/localhost/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:utopic-20150625
+FROM ubuntu:vivid
 
 RUN apt-get update
 RUN apt-get -y install git build-essential clang cmake


### PR DESCRIPTION
utopic is no longer supported (although still appearing in the docker hub), when running `apt-get update` inside the docker I get many 404 messages such as:
```
W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/utopic/main/source/Sources  404  Not Found [IP: 91.189.91.23 80]
W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/utopic/restricted/source/Sources  404  Not Found [IP: 91.189.91.23 80]
W: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/utopic/universe/source/Sources  404  Not Found [IP: 91.189.91.23 80]
```

Changed `FROM` to `vivid`, everything works as expected now.