### PR TITLE
Add an option to enable/disable the forward declaration of records and enums

### DIFF
--- a/src/source/CppMarshal.scala
+++ b/src/source/CppMarshal.scala
@@ -47,7 +47,7 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
     case d: MDef => d.defType match {
       case DRecord =>
         if (d.name != exclude) {
-          if (forwardDeclareOnly) {
+          if (forwardDeclareOnly && spec.cppUseForwardDeclarations) {
             List(DeclRef(s"struct ${typename(d.name, d.body)};", Some(spec.cppNamespace)))
           } else {
             List(ImportRef(include(d.name)))
@@ -57,7 +57,7 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
         }
       case DEnum =>
         if (d.name != exclude) {
-          if (forwardDeclareOnly) {
+          if (forwardDeclareOnly && spec.cppUseForwardDeclarations) {
             List(DeclRef(s"enum class ${typename(d.name, d.body)};", Some(spec.cppNamespace)))
           } else {
             List(ImportRef(include(d.name)))

--- a/src/source/Main.scala
+++ b/src/source/Main.scala
@@ -31,6 +31,7 @@ object Main {
     var cppOptionalTemplate: String = "std::optional"
     var cppOptionalHeader: String = "<optional>"
     var cppEnumHashWorkaround : Boolean = true
+    var cppUseForwardDeclarations : Boolean = true
     var cppNnHeader: Option[String] = None
     var cppNnType: Option[String] = None
     var cppNnCheckExpression: Option[String] = None
@@ -122,6 +123,8 @@ object Main {
         .text("The header to use for optional values (default: \"<optional>\")")
       opt[Boolean]("cpp-enum-hash-workaround").valueName("<true/false>").foreach(x => cppEnumHashWorkaround = x)
         .text("Work around LWG-2148 by generating std::hash specializations for C++ enums (default: true)")
+      opt[Boolean]("cpp-use-forward-declarations").valueName("<true/false>").foreach(x => cppUseForwardDeclarations = x)
+        .text("Use forward declarations for records and enums in C++ (default: true)")
       opt[String]("cpp-nn-header").valueName("<header>").foreach(x => cppNnHeader = Some(x))
         .text("The header to use for non-nullable pointers")
       opt[String]("cpp-nn-type").valueName("<header>").foreach(x => cppNnType = Some(x))
@@ -279,6 +282,7 @@ object Main {
       cppOptionalTemplate,
       cppOptionalHeader,
       cppEnumHashWorkaround,
+	  cppUseForwardDeclarations,
       cppNnHeader,
       cppNnType,
       cppNnCheckExpression,

--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -44,6 +44,7 @@ package object generatorTools {
                    cppOptionalTemplate: String,
                    cppOptionalHeader: String,
                    cppEnumHashWorkaround: Boolean,
+                   cppUseForwardDeclarations: Boolean,
                    cppNnHeader: Option[String],
                    cppNnType: Option[String],
                    cppNnCheckExpression: Option[String],


### PR DESCRIPTION
Hi

I am again working on Djinni with C++ /CX and C++ /CLI to use Djinni together with managed Code and for the Windows Phone.

Unfortunately it seems like the C++ /CLI on Visual Studio 2012 does not like Forward declarations on structs and enums. Therefore I added a command line Switch to the Djinni Source Code to enable/disable the forward declaration Feature.

Feel free to pull this Change into Djinni main. If I've missed something in my implemenation please let me know and I'll fix it.

Later on I plan to give you a pull-request on my current work with the C++ /CLI and the C++ /CX Generator. 

Cheers
Christian

