### PR TITLE
root import error

### DIFF
--- a/src/source/parser.scala
+++ b/src/source/parser.scala
@@ -33,20 +33,24 @@ case class Parser() {
 
 val visitedFiles = mutable.Set[File]()
 val fileStack = mutable.Stack[File]()
-def fileParent:String = if (fileStack.top.getParent() != null) return fileStack.top.getParent() + "/" else return ""
 
 private object IdlParser extends RegexParsers {
   override protected val whiteSpace = """[ \t\n\r]+""".r
 
   def idlFile(origin: String): Parser[IdlFile] = rep(importFile) ~ rep(typeDecl(origin)) ^^ { case imp~types => IdlFile(imp, types) }
 
-  def importFile: Parser[FileRef] = ("@" ~> directive) ~ ("\"" ~> filePath <~ "\"") ^^ {
-    case "import" ~ x =>
-      val newPath = fileParent + x
-      new IdlFileRef(new File(newPath))
-    case "extern" ~ x =>
-      val newPath = fileParent + x
-      new ExternFileRef(new File(newPath))
+  def importFile: Parser[FileRef] = {
+    
+	def fileParent:String = if (fileStack.top.getParent() != null) return fileStack.top.getParent() + "/" else return ""
+
+    ("@" ~> directive) ~ ("\"" ~> filePath <~ "\"") ^^ {
+      case "import" ~ x =>
+        val newPath = fileParent + x
+        new IdlFileRef(new File(newPath))
+      case "extern" ~ x =>
+        val newPath = fileParent + x
+        new ExternFileRef(new File(newPath))
+    }
   }
   def filePath = "[^\"]*".r
 

--- a/src/source/parser.scala
+++ b/src/source/parser.scala
@@ -33,6 +33,7 @@ case class Parser() {
 
 val visitedFiles = mutable.Set[File]()
 val fileStack = mutable.Stack[File]()
+def fileParent:String = if (fileStack.top.getParent() != null) return fileStack.top.getParent() + "/" else return ""
 
 private object IdlParser extends RegexParsers {
   override protected val whiteSpace = """[ \t\n\r]+""".r
@@ -41,10 +42,10 @@ private object IdlParser extends RegexParsers {
 
   def importFile: Parser[FileRef] = ("@" ~> directive) ~ ("\"" ~> filePath <~ "\"") ^^ {
     case "import" ~ x =>
-      val newPath = fileStack.top.getParent() + "/" + x
+      val newPath = fileParent + x
       new IdlFileRef(new File(newPath))
     case "extern" ~ x =>
-      val newPath = fileStack.top.getParent() + "/" + x
+      val newPath = fileParent + x
       new ExternFileRef(new File(newPath))
   }
   def filePath = "[^\"]*".r


### PR DESCRIPTION
If djinni files were at the root level of the project and one file imported another it would fail with a "null/<filename>" not found.  This fix makes the fileParent a function that tests for nullness and just returns the empty string if necessary.