### PR TITLE
Xcode 7.3 adds a warning if we print an Objective-C class as a pointer...

### DIFF
--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -395,7 +395,7 @@ class ObjcGenerator(spec: Spec) extends Generator(spec) {
           w.w("[NSString stringWithFormat:@\"<%@ %p")
 
           for (f <- r.fields) w.w(s" ${idObjc.field(f.ident)}:%@")
-          w.w(">\", self.class, self")
+          w.w(">\", self.class, (void *)self")
 
           for (f <- r.fields) {
             w.w(", ")

--- a/test-suite/generated-src/objc/DBAssortedPrimitives.mm
+++ b/test-suite/generated-src/objc/DBAssortedPrimitives.mm
@@ -114,7 +114,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p b:%@ eight:%@ sixteen:%@ thirtytwo:%@ sixtyfour:%@ fthirtytwo:%@ fsixtyfour:%@ oB:%@ oEight:%@ oSixteen:%@ oThirtytwo:%@ oSixtyfour:%@ oFthirtytwo:%@ oFsixtyfour:%@>", self.class, self, @(self.b), @(self.eight), @(self.sixteen), @(self.thirtytwo), @(self.sixtyfour), @(self.fthirtytwo), @(self.fsixtyfour), self.oB, self.oEight, self.oSixteen, self.oThirtytwo, self.oSixtyfour, self.oFthirtytwo, self.oFsixtyfour];
+    return [NSString stringWithFormat:@"<%@ %p b:%@ eight:%@ sixteen:%@ thirtytwo:%@ sixtyfour:%@ fthirtytwo:%@ fsixtyfour:%@ oB:%@ oEight:%@ oSixteen:%@ oThirtytwo:%@ oSixtyfour:%@ oFthirtytwo:%@ oFsixtyfour:%@>", self.class, (void *)self, @(self.b), @(self.eight), @(self.sixteen), @(self.thirtytwo), @(self.sixtyfour), @(self.fthirtytwo), @(self.fsixtyfour), self.oB, self.oEight, self.oSixteen, self.oThirtytwo, self.oSixtyfour, self.oFthirtytwo, self.oFsixtyfour];
 }
 
 @end

--- a/test-suite/generated-src/objc/DBClientReturnedRecord.mm
+++ b/test-suite/generated-src/objc/DBClientReturnedRecord.mm
@@ -29,7 +29,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p recordId:%@ content:%@ misc:%@>", self.class, self, @(self.recordId), self.content, self.misc];
+    return [NSString stringWithFormat:@"<%@ %p recordId:%@ content:%@ misc:%@>", self.class, (void *)self, @(self.recordId), self.content, self.misc];
 }
 
 @end

--- a/test-suite/generated-src/objc/DBConstantRecord.mm
+++ b/test-suite/generated-src/objc/DBConstantRecord.mm
@@ -25,7 +25,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p someInteger:%@ someString:%@>", self.class, self, @(self.someInteger), self.someString];
+    return [NSString stringWithFormat:@"<%@ %p someInteger:%@ someString:%@>", self.class, (void *)self, @(self.someInteger), self.someString];
 }
 
 @end

--- a/test-suite/generated-src/objc/DBConstants.mm
+++ b/test-suite/generated-src/objc/DBConstants.mm
@@ -61,7 +61,7 @@ BOOL const DBConstantsDummy = NO;
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p>", self.class, self];
+    return [NSString stringWithFormat:@"<%@ %p>", self.class, (void *)self];
 }
 
 @end

--- a/test-suite/generated-src/objc/DBDateRecord.mm
+++ b/test-suite/generated-src/objc/DBDateRecord.mm
@@ -46,7 +46,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p createdAt:%@>", self.class, self, self.createdAt];
+    return [NSString stringWithFormat:@"<%@ %p createdAt:%@>", self.class, (void *)self, self.createdAt];
 }
 
 @end

--- a/test-suite/generated-src/objc/DBEmptyRecord.mm
+++ b/test-suite/generated-src/objc/DBEmptyRecord.mm
@@ -20,7 +20,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p>", self.class, self];
+    return [NSString stringWithFormat:@"<%@ %p>", self.class, (void *)self];
 }
 
 @end

--- a/test-suite/generated-src/objc/DBExternRecordWithDerivings.mm
+++ b/test-suite/generated-src/objc/DBExternRecordWithDerivings.mm
@@ -62,7 +62,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p member:%@ e:%@>", self.class, self, self.member, @(self.e)];
+    return [NSString stringWithFormat:@"<%@ %p member:%@ e:%@>", self.class, (void *)self, self.member, @(self.e)];
 }
 
 @end

--- a/test-suite/generated-src/objc/DBMapDateRecord.mm
+++ b/test-suite/generated-src/objc/DBMapDateRecord.mm
@@ -21,7 +21,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p datesById:%@>", self.class, self, self.datesById];
+    return [NSString stringWithFormat:@"<%@ %p datesById:%@>", self.class, (void *)self, self.datesById];
 }
 
 @end

--- a/test-suite/generated-src/objc/DBMapListRecord.mm
+++ b/test-suite/generated-src/objc/DBMapListRecord.mm
@@ -21,7 +21,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p mapList:%@>", self.class, self, self.mapList];
+    return [NSString stringWithFormat:@"<%@ %p mapList:%@>", self.class, (void *)self, self.mapList];
 }
 
 @end

--- a/test-suite/generated-src/objc/DBMapRecord.mm
+++ b/test-suite/generated-src/objc/DBMapRecord.mm
@@ -25,7 +25,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p map:%@ imap:%@>", self.class, self, self.map, self.imap];
+    return [NSString stringWithFormat:@"<%@ %p map:%@ imap:%@>", self.class, (void *)self, self.map, self.imap];
 }
 
 @end

--- a/test-suite/generated-src/objc/DBNestedCollection.mm
+++ b/test-suite/generated-src/objc/DBNestedCollection.mm
@@ -21,7 +21,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p setList:%@>", self.class, self, self.setList];
+    return [NSString stringWithFormat:@"<%@ %p setList:%@>", self.class, (void *)self, self.setList];
 }
 
 @end

--- a/test-suite/generated-src/objc/DBOptColorRecord.mm
+++ b/test-suite/generated-src/objc/DBOptColorRecord.mm
@@ -21,7 +21,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p myColor:%@>", self.class, self, self.myColor];
+    return [NSString stringWithFormat:@"<%@ %p myColor:%@>", self.class, (void *)self, self.myColor];
 }
 
 @end

--- a/test-suite/generated-src/objc/DBPrimitiveList.mm
+++ b/test-suite/generated-src/objc/DBPrimitiveList.mm
@@ -21,7 +21,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p list:%@>", self.class, self, self.list];
+    return [NSString stringWithFormat:@"<%@ %p list:%@>", self.class, (void *)self, self.list];
 }
 
 @end

--- a/test-suite/generated-src/objc/DBRecordWithDerivings.mm
+++ b/test-suite/generated-src/objc/DBRecordWithDerivings.mm
@@ -62,7 +62,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p key1:%@ key2:%@>", self.class, self, @(self.key1), self.key2];
+    return [NSString stringWithFormat:@"<%@ %p key1:%@ key2:%@>", self.class, (void *)self, @(self.key1), self.key2];
 }
 
 @end

--- a/test-suite/generated-src/objc/DBRecordWithDurationAndDerivings.mm
+++ b/test-suite/generated-src/objc/DBRecordWithDurationAndDerivings.mm
@@ -52,7 +52,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p dt:%@>", self.class, self, @(self.dt)];
+    return [NSString stringWithFormat:@"<%@ %p dt:%@>", self.class, (void *)self, @(self.dt)];
 }
 
 @end

--- a/test-suite/generated-src/objc/DBRecordWithNestedDerivings.mm
+++ b/test-suite/generated-src/objc/DBRecordWithNestedDerivings.mm
@@ -62,7 +62,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p key:%@ rec:%@>", self.class, self, @(self.key), self.rec];
+    return [NSString stringWithFormat:@"<%@ %p key:%@ rec:%@>", self.class, (void *)self, @(self.key), self.rec];
 }
 
 @end

--- a/test-suite/generated-src/objc/DBSetRecord.mm
+++ b/test-suite/generated-src/objc/DBSetRecord.mm
@@ -25,7 +25,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@ %p set:%@ iset:%@>", self.class, self, self.set, self.iset];
+    return [NSString stringWithFormat:@"<%@ %p set:%@ iset:%@>", self.class, (void *)self, self.set, self.iset];
 }
 
 @end


### PR DESCRIPTION
… without an explicit cast. (`-Wformat-pedantic`).

This PR fixes this future issue.