### PR TITLE
add yaml files to outFileList when --skip-generation is enabled

### DIFF
--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -199,8 +199,8 @@ package object generatorTools {
       if (spec.yamlOutFolder.isDefined) {
         if (!spec.skipGeneration) {
           createFolder("YAML", spec.yamlOutFolder.get)
-          new YamlGenerator(spec).generate(idl)
         }
+        new YamlGenerator(spec).generate(idl)
       }
       None
     }


### PR DESCRIPTION
When --skip-generation is enabled yaml files aren't be added to the out file list.