### PR TITLE
Implements interface inheritance in Djinni. 

### DIFF
--- a/src/source/CppMarshal.scala
+++ b/src/source/CppMarshal.scala
@@ -20,6 +20,11 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
     case r: Record => withNs(Some(spec.cppNamespace), idCpp.ty(name))
   }
 
+  def superTypename(ty: TypeDef): Option[String] = ty match {
+    case i: Interface => if (i.superIdent.isDefined) Some(i.superIdent.get.name) else None
+    case _ => None
+  }
+
   override def paramType(tm: MExpr): String = toCppParamType(tm)
   override def fqParamType(tm: MExpr): String = toCppParamType(tm, Some(spec.cppNamespace))
 

--- a/src/source/JavaGenerator.scala
+++ b/src/source/JavaGenerator.scala
@@ -119,16 +119,22 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
     })
   }
 
-  override def generateInterface(origin: String, ident: Ident, doc: Doc, typeParams: Seq[TypeParam], i: Interface) {
+  override def generateInterface(idl: Seq[TypeDecl], origin: String, ident: Ident, doc: Doc, typeParams: Seq[TypeParam], i: Interface) {
     val refs = new JavaRefs()
 
-    i.methods.map(m => {
-      m.params.map(p => refs.find(p.ty))
-      m.ret.foreach(refs.find)
-    })
-    i.consts.map(c => {
-      refs.find(c.ty)
-    })
+    def mapRefs(i: Interface) {
+      i.methods.map(m => {
+        m.params.map(p => refs.find(p.ty))
+        m.ret.foreach(refs.find)
+      })
+      i.consts.map(c => {
+        refs.find(c.ty)
+      })
+    }
+
+    marshal.superInterfacesForInterface(i, idl).foreach { mapRefs(_) }
+    mapRefs(i)
+
     if (i.ext.cpp) {
       refs.java.add("java.util.concurrent.atomic.AtomicBoolean")
     }
@@ -139,7 +145,12 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
       writeDoc(w, doc)
 
       javaAnnotationHeader.foreach(w.wl)
-      w.w(s"public abstract class $javaClass$typeParamList").braced {
+
+      val superTypename = marshal.superTypename(i)
+
+      // In java we need to add an "extends Type" to a class to subclass it.
+      val extendsDef = if (superTypename.isDefined) " extends " + superTypename.get else ""
+      w.w(s"public abstract class $javaClass$typeParamList$extendsDef").braced {
         val skipFirst = SkipFirst()
         generateJavaConstants(w, i.consts)
 
@@ -187,24 +198,38 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
               w.wl("destroy();")
               w.wl("super.finalize();")
             }
-            for (m <- i.methods if !m.static) { // Static methods not in CppProxy
-              val ret = marshal.returnType(m.ret)
-              val returnStmt = m.ret.fold("")(_ => "return ")
-              val params = m.params.map(p => marshal.paramType(p.ty) + " " + idJava.local(p.ident)).mkString(", ")
-              val args = m.params.map(p => idJava.local(p.ident)).mkString(", ")
-              val meth = idJava.method(m.ident)
-              w.wl
-              w.wl(s"@Override")
-              w.wl(s"public $ret $meth($params)$throwException").braced {
-                w.wl("assert !this.destroyed.get() : \"trying to use a destroyed object\";")
-                w.wl(s"${returnStmt}native_$meth(this.nativeRef${preComma(args)});")
-              }
-              w.wl(s"private native $ret native_$meth(long _nativeRef${preComma(params)});")
+
+            // For JNI support, Djinni generates a nested class, called CppProxy, which handles the bridging
+            // between Java and C++. The super interface methods need to be declared within the proxy.
+            w.wl; w.wl(s"// $javaClass methods")
+            writeCppProxyMethods(w, i.methods, throwException)
+
+            val superMethods = getInterfaceSuperMethods(i, idl)
+            if (!superMethods.isEmpty) {
+              w.wl; w.wl(s"// ${superTypename.getOrElse("Super")} methods")
+              writeCppProxyMethods(w, superMethods, throwException)
             }
           }
         }
       }
     })
+  }
+
+  def writeCppProxyMethods(w: IndentWriter, methods: Seq[Interface.Method], throwException: String) {
+    for (m <- methods if !m.static) { // Static methods not in CppProxy
+      val ret = marshal.returnType(m.ret)
+      val returnStmt = m.ret.fold("")(_ => "return ")
+      val params = m.params.map(p => marshal.paramType(p.ty) + " " + idJava.local(p.ident)).mkString(", ")
+      val args = m.params.map(p => idJava.local(p.ident)).mkString(", ")
+      val meth = idJava.method(m.ident)
+      w.wl
+      w.wl(s"@Override")
+      w.wl(s"public $ret $meth($params)$throwException").braced {
+        w.wl("assert !this.destroyed.get() : \"trying to use a destroyed object\";")
+        w.wl(s"${returnStmt}native_$meth(this.nativeRef${preComma(args)});")
+      }
+      w.wl(s"private native $ret native_$meth(long _nativeRef${preComma(params)});")
+    }
   }
 
   override def generateRecord(origin: String, ident: Ident, doc: Doc, params: Seq[TypeParam], r: Record) {

--- a/src/source/JavaMarshal.scala
+++ b/src/source/JavaMarshal.scala
@@ -12,6 +12,11 @@ class JavaMarshal(spec: Spec) extends Marshal(spec) {
   override def typename(tm: MExpr): String = toJavaType(tm, None)
   def typename(name: String, ty: TypeDef): String = idJava.ty(name)
 
+  def superTypename(ty: TypeDef): Option[String] = ty match {
+    case i: Interface => if(i.superIdent.isDefined) Some(idJava.ty(i.superIdent.get.name)) else None
+    case _ => None
+  }
+
   override def fqTypename(tm: MExpr): String = toJavaType(tm, spec.javaPackage)
   def fqTypename(name: String, ty: TypeDef): String = withPackage(spec.javaPackage, idJava.ty(name))
 

--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -117,7 +117,7 @@ class ObjcGenerator(spec: Spec) extends Generator(spec) {
     w.wl("#pragma clang diagnostic pop")
   }
 
-  override def generateInterface(origin: String, ident: Ident, doc: Doc, typeParams: Seq[TypeParam], i: Interface) {
+  override def generateInterface(idl: Seq[TypeDecl], origin: String, ident: Ident, doc: Doc, typeParams: Seq[TypeParam], i: Interface) {
     val refs = new ObjcRefs()
     i.methods.map(m => {
       m.params.map(p => refs.find(p.ty))
@@ -130,6 +130,10 @@ class ObjcGenerator(spec: Spec) extends Generator(spec) {
     val self = marshal.typename(ident, i)
 
     refs.header.add("#import <Foundation/Foundation.h>")
+
+    if (i.superIdent.isDefined) {
+      refs.header.add ("#import " + q(spec.objcIncludePrefix + marshal.headerName(i.superIdent.get)))
+    }
 
     def writeObjcFuncDecl(method: Interface.Method, w: IndentWriter) {
       val label = if (method.static) "+" else "-"
@@ -147,7 +151,11 @@ class ObjcGenerator(spec: Spec) extends Generator(spec) {
       }
       w.wl
       writeDoc(w, doc)
-      if (i.ext.objc) w.wl(s"@protocol $self") else w.wl(s"@interface $self : NSObject")
+
+      // Top level Djinni protocols need to extend NSObject. Without extending NSObject, protocols can't leverage
+      // methods like respondsToSelector when the instance variable is of the form id<ProtocolName> ivarName;
+      val superTypename = marshal.superTypename(i).getOrElse("NSObject")
+      if (i.ext.objc) w.wl(s"@protocol $self <$superTypename>") else w.wl(s"@interface $self : $superTypename")
       for (m <- i.methods) {
         w.wl
         writeDoc(w, m.doc)

--- a/src/source/ObjcMarshal.scala
+++ b/src/source/ObjcMarshal.scala
@@ -12,6 +12,11 @@ class ObjcMarshal(spec: Spec) extends Marshal(spec) {
   }
   def typename(name: String, ty: TypeDef): String = idObjc.ty(name)
 
+  def superTypename(ty: TypeDef): Option[String] = ty match {
+    case i: Interface => if(i.superIdent.isDefined) Some(idObjc.ty(i.superIdent.get.name)) else None
+    case _ => None
+  }
+
   override def fqTypename(tm: MExpr): String = typename(tm)
   def fqTypename(name: String, ty: TypeDef): String = typename(name, ty)
 

--- a/src/source/ObjcppGenerator.scala
+++ b/src/source/ObjcppGenerator.scala
@@ -57,9 +57,13 @@ class ObjcppGenerator(spec: Spec) extends Generator(spec) {
 
   def nnCheck(expr: String): String = spec.cppNnCheckExpression.fold(expr)(check => s"$check($expr)")
 
-  override def generateInterface(origin: String, ident: Ident, doc: Doc, typeParams: Seq[TypeParam], i: Interface) {
+  override def generateInterface(idl: Seq[TypeDecl], origin: String, ident: Ident, doc: Doc, typeParams: Seq[TypeParam], i: Interface) {
     val refs = new ObjcRefs()
     i.methods.map(m => {
+      m.params.map(p => refs.find(p.ty))
+      m.ret.foreach(refs.find)
+    })
+    getInterfaceSuperMethods(i, idl).map(m => {
       m.params.map(p => refs.find(p.ty))
       m.ret.foreach(refs.find)
     })
@@ -72,18 +76,15 @@ class ObjcppGenerator(spec: Spec) extends Generator(spec) {
 
     refs.privHeader.add("#include <memory>")
     refs.privHeader.add("!#include " + q(spec.objcppIncludeCppPrefix + spec.cppFileIdentStyle(ident) + "." + spec.cppHeaderExt))
+    if (i.superIdent.isDefined) {
+      refs.privHeader.add("#import " + q(spec.objcppIncludePrefix + objcppMarshal.privateHeaderName(i.superIdent.get.name)));
+    }
+
     refs.body.add("!#import " + q(spec.objcppIncludeObjcPrefix + headerName(ident)))
 
     spec.cppNnHeader match {
       case Some(nnHdr) => refs.privHeader.add("#include " + nnHdr)
       case _ =>
-    }
-
-    def writeObjcFuncDecl(method: Interface.Method, w: IndentWriter) {
-      val label = if (method.static) "+" else "-"
-      val ret = objcMarshal.fqReturnType(method.ret)
-      val decl = s"$label ($ret)${idObjc.method(method.ident)}"
-      writeAlignedObjcCall(w, decl, method.params, "", p => (idObjc.field(p.ident), s"(${objcMarshal.paramType(p.ty)})${idObjc.local(p.ident)}"))
     }
 
     val helperClass = objcppMarshal.helperClass(ident)
@@ -159,32 +160,14 @@ class ObjcppGenerator(spec: Spec) extends Generator(spec) {
           }
           w.wl("return self;")
         }
-        for (m <- i.methods) {
-          w.wl
-          writeObjcFuncDecl(m, w)
-          w.braced {
-            w.w("try").bracedEnd(" DJINNI_TRANSLATE_EXCEPTIONS()") {
-              m.params.foreach(p => {
-                if (isInterface(p.ty.resolved) && spec.cppNnCheckExpression.nonEmpty) {
-                  // We have a non-optional interface, assert that we're getting a non-null value
-                  val paramName = idObjc.local(p.ident)
-                  val stringWriter = new StringWriter()
-                  writeObjcFuncDecl(m, new IndentWriter(stringWriter))
-                  val singleLineFunctionDecl = stringWriter.toString.replaceAll("\n *", " ")
-                  val exceptionReason = s"Got unexpected null parameter '$paramName' to function $objcSelf $singleLineFunctionDecl"
-                  w.w(s"if ($paramName == nil)").braced {
-                    w.wl(s"""throw std::invalid_argument("$exceptionReason");""")
-                  }
-                }
-              })
-              val ret = m.ret.fold("")(_ => "auto r = ")
-              val call = ret + (if (!m.static) "_cppRefHandle.get()->" else cppSelf + "::") + idCpp.method(m.ident) + "("
-              writeAlignedCall(w, call, m.params, ")", p => objcppMarshal.toCpp(p.ty, idObjc.local(p.ident.name)))
 
-              w.wl(";")
-              m.ret.fold()(r => w.wl(s"return ${objcppMarshal.fromCpp(r, "r")};"))
-            }
-          }
+        w.wl; w.wl(s"// $objcSelf methods")
+        writeCppProxyMethods(w, i.methods, objcSelf, cppSelf)
+
+        val superMethods = getInterfaceSuperMethods(i, idl)
+        if (!superMethods.isEmpty) {
+          w.wl; w.wl(s"// ${objcppMarshal.superTypename(i).getOrElse("Super")} methods")
+          writeCppProxyMethods(w, superMethods, objcSelf, cppSelf)
         }
       }
 
@@ -289,6 +272,43 @@ class ObjcppGenerator(spec: Spec) extends Generator(spec) {
         w.wl("@end")
       }
     })
+  }
+
+  def writeObjcFuncDecl(method: Interface.Method, w: IndentWriter) {
+    val label = if (method.static) "+" else "-"
+    val ret = objcMarshal.fqReturnType(method.ret)
+    val decl = s"$label ($ret)${idObjc.method(method.ident)}"
+    writeAlignedObjcCall(w, decl, method.params, "", p => (idObjc.field(p.ident), s"(${objcMarshal.paramType(p.ty)})${idObjc.local(p.ident)}"))
+  }
+
+  def writeCppProxyMethods(w: IndentWriter, methods: Seq[Interface.Method], objcName: String, cppName: String) {
+    for (m <- methods) {
+      w.wl
+      writeObjcFuncDecl(m, w)
+      w.braced {
+        w.w("try").bracedEnd(" DJINNI_TRANSLATE_EXCEPTIONS()") {
+          m.params.foreach(p => {
+            if (isInterface(p.ty.resolved) && spec.cppNnCheckExpression.nonEmpty) {
+              // We have a non-optional interface, assert that we're getting a non-null value
+              val paramName = idObjc.local(p.ident)
+              val stringWriter = new StringWriter()
+              writeObjcFuncDecl(m, new IndentWriter(stringWriter))
+              val singleLineFunctionDecl = stringWriter.toString.replaceAll("\n *", " ")
+              val exceptionReason = s"Got unexpected null parameter '$paramName' to function $objcName $singleLineFunctionDecl"
+              w.w(s"if ($paramName == nil)").braced {
+                w.wl(s"""throw std::invalid_argument("$exceptionReason");""")
+              }
+            }
+          })
+          val ret = m.ret.fold("")(_ => "auto r = ")
+          val call = ret + (if (!m.static) "_cppRefHandle.get()->" else cppName + "::") + idCpp.method(m.ident) + "("
+          writeAlignedCall(w, call, m.params, ")", p => objcppMarshal.toCpp(p.ty, idObjc.local(p.ident.name)))
+
+          w.wl(";")
+          m.ret.fold()(r => w.wl(s"return ${objcppMarshal.fromCpp(r, "r")};"))
+        }
+      }
+    }
   }
 
   override def generateRecord(origin: String, ident: Ident, doc: Doc, params: Seq[TypeParam], r: Record) {

--- a/src/source/ObjcppMarshal.scala
+++ b/src/source/ObjcppMarshal.scala
@@ -11,6 +11,8 @@ class ObjcppMarshal(spec: Spec) extends Marshal(spec) {
   override def typename(tm: MExpr): String = throw new AssertionError("not applicable")
   def typename(name: String, ty: TypeDef): String = throw new AssertionError("not applicable")
 
+  def superTypename(ty: TypeDef): Option[String] = objcMarshal.superTypename(ty)
+
   override def fqTypename(tm: MExpr): String = throw new AssertionError("not applicable")
   def fqTypename(name: String, ty: TypeDef): String = throw new AssertionError("not applicable")
 

--- a/src/source/YamlGenerator.scala
+++ b/src/source/YamlGenerator.scala
@@ -171,7 +171,7 @@ class YamlGenerator(spec: Spec) extends Generator(spec) {
     // unused
   }
 
-  override def generateInterface(origin: String, ident: Ident, doc: Doc, typeParams: Seq[TypeParam], i: Interface) {
+  override def generateInterface(idl: Seq[TypeDecl], origin: String, ident: Ident, doc: Doc, typeParams: Seq[TypeParam], i: Interface) {
     // unused
   }
 

--- a/src/source/ast.scala
+++ b/src/source/ast.scala
@@ -74,7 +74,7 @@ object Record {
   }
 }
 
-case class Interface(ext: Ext, methods: Seq[Interface.Method], consts: Seq[Const]) extends TypeDef
+case class Interface(superIdent: Option[Ident], ext: Ext, methods: Seq[Interface.Method], consts: Seq[Const]) extends TypeDef
 object Interface {
   case class Method(ident: Ident, params: Seq[Field], ret: Option[TypeRef], doc: Doc, static: Boolean, const: Boolean)
 }

--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -468,12 +468,13 @@ void jniDefaultSetPendingFromCurrent(JNIEnv * env, const char * /*ctx*/) noexcep
 template class ProxyCache<JavaProxyCacheTraits>;
 
 CppProxyClassInfo::CppProxyClassInfo(const char * className)
-    : clazz(jniFindClass(className)),
+    : proxyClassName{std::string(className)},
+      clazz(jniFindClass(className)),
       constructor(jniGetMethodID(clazz.get(), "<init>", "(J)V")),
       idField(jniGetFieldID(clazz.get(), "nativeRef", "J")) {
 }
 
-CppProxyClassInfo::CppProxyClassInfo() : constructor{}, idField{} {
+CppProxyClassInfo::CppProxyClassInfo() : proxyClassName{}, constructor{}, idField{} {
 }
 
 CppProxyClassInfo::~CppProxyClassInfo() {

--- a/support-lib/objc/DJICppWrapperCache+Private.h
+++ b/support-lib/objc/DJICppWrapperCache+Private.h
@@ -16,8 +16,8 @@
 
 //  This header can only be imported to Objective-C++ source code!
 
-#import <Foundation/Foundation.h>
 #include <memory>
+#include <objc/runtime.h>
 
 #include "../proxy_cache_interface.hpp"
 
@@ -44,8 +44,9 @@ ObjcType * get_cpp_proxy_impl(const std::shared_ptr<CppType> & cppRef) {
         typeid(cppRef),
         cppRef,
         [] (const std::shared_ptr<void> & cppRef) -> std::pair<id, void *> {
+            auto castCppRef = std::static_pointer_cast<CppType>(cppRef);
             return {
-                [[ObjcType alloc] initWithCpp:std::static_pointer_cast<CppType>(cppRef)],
+                [((ObjcType *)[objc_getClass(castCppRef->objcTypeName().c_str()) alloc]) initWithCpp:castCppRef],
                 cppRef.get()
             };
         }


### PR DESCRIPTION
Includes:

* New 'interface extends' syntax support.
* Code generation for interfaces that extend other interfaces.
* Proper object conversion from one language to another. No type slicing when references as a super interface.