### PR TITLE
Generate default constructors for c++ records

### DIFF
--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -182,6 +182,9 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
           w.wl(s"friend bool operator>=(const $actualSelf& lhs, const $actualSelf& rhs);")
         }
 
+        w.wl
+        w.wl(actualSelf + "() = default;")
+
         // Constructor.
         if(r.fields.nonEmpty) {
           w.wl


### PR DESCRIPTION
Records can exist as fields within classes. When a record has no
default constructor, it prevents us from using records in classes
that have default constructors. Furthermore, even in cases where
non-default constructors are used, it may not be desireable to
initialize records with specific values at a later point in time.
We could use the brace initializers as a "hack" to get around the
lack of a default constructor, but I would consider using those
types of language constructs to be a poor alternative in this case.