### PR TITLE
Changed Namespace for CppProxy to global ::djinni in JNIGenerator

### DIFF
--- a/example/generated-src/jni/NativeSortItems.cpp
+++ b/example/generated-src/jni/NativeSortItems.cpp
@@ -18,7 +18,7 @@ CJNIEXPORT void JNICALL Java_com_dropbox_textsort_SortItems_00024CppProxy_native
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
-        delete reinterpret_cast<djinni::CppProxyHandle<::textsort::SortItems>*>(nativeRef);
+        delete reinterpret_cast<::djinni::CppProxyHandle<::textsort::SortItems>*>(nativeRef);
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 

--- a/src/source/JNIGenerator.scala
+++ b/src/source/JNIGenerator.scala
@@ -334,7 +334,7 @@ class JNIGenerator(spec: Spec) extends Generator(spec) {
           }
         }
         nativeHook("nativeDestroy", false, Seq.empty, None, {
-          w.wl(s"delete reinterpret_cast<djinni::CppProxyHandle<$cppSelf>*>(nativeRef);")
+          w.wl(s"delete reinterpret_cast<::djinni::CppProxyHandle<$cppSelf>*>(nativeRef);")
         })
         for (m <- i.methods) {
           val nativeAddon = if (m.static) "" else "native_"

--- a/test-suite/generated-src/jni/NativeConstantsInterface.cpp
+++ b/test-suite/generated-src/jni/NativeConstantsInterface.cpp
@@ -16,7 +16,7 @@ CJNIEXPORT void JNICALL Java_com_dropbox_djinni_test_ConstantsInterface_00024Cpp
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
-        delete reinterpret_cast<djinni::CppProxyHandle<::testsuite::ConstantsInterface>*>(nativeRef);
+        delete reinterpret_cast<::djinni::CppProxyHandle<::testsuite::ConstantsInterface>*>(nativeRef);
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 

--- a/test-suite/generated-src/jni/NativeCppException.cpp
+++ b/test-suite/generated-src/jni/NativeCppException.cpp
@@ -16,7 +16,7 @@ CJNIEXPORT void JNICALL Java_com_dropbox_djinni_test_CppException_00024CppProxy_
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
-        delete reinterpret_cast<djinni::CppProxyHandle<::testsuite::CppException>*>(nativeRef);
+        delete reinterpret_cast<::djinni::CppProxyHandle<::testsuite::CppException>*>(nativeRef);
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 

--- a/test-suite/generated-src/jni/NativeExternInterface1.cpp
+++ b/test-suite/generated-src/jni/NativeExternInterface1.cpp
@@ -16,7 +16,7 @@ CJNIEXPORT void JNICALL Java_com_dropbox_djinni_test_ExternInterface1_00024CppPr
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
-        delete reinterpret_cast<djinni::CppProxyHandle<::ExternInterface1>*>(nativeRef);
+        delete reinterpret_cast<::djinni::CppProxyHandle<::ExternInterface1>*>(nativeRef);
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 

--- a/test-suite/generated-src/jni/NativeListenerCaller.cpp
+++ b/test-suite/generated-src/jni/NativeListenerCaller.cpp
@@ -17,7 +17,7 @@ CJNIEXPORT void JNICALL Java_com_dropbox_djinni_test_ListenerCaller_00024CppProx
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
-        delete reinterpret_cast<djinni::CppProxyHandle<::testsuite::ListenerCaller>*>(nativeRef);
+        delete reinterpret_cast<::djinni::CppProxyHandle<::testsuite::ListenerCaller>*>(nativeRef);
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 

--- a/test-suite/generated-src/jni/NativeReturnOne.cpp
+++ b/test-suite/generated-src/jni/NativeReturnOne.cpp
@@ -16,7 +16,7 @@ CJNIEXPORT void JNICALL Java_com_dropbox_djinni_test_ReturnOne_00024CppProxy_nat
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
-        delete reinterpret_cast<djinni::CppProxyHandle<::testsuite::ReturnOne>*>(nativeRef);
+        delete reinterpret_cast<::djinni::CppProxyHandle<::testsuite::ReturnOne>*>(nativeRef);
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 

--- a/test-suite/generated-src/jni/NativeReturnTwo.cpp
+++ b/test-suite/generated-src/jni/NativeReturnTwo.cpp
@@ -16,7 +16,7 @@ CJNIEXPORT void JNICALL Java_com_dropbox_djinni_test_ReturnTwo_00024CppProxy_nat
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
-        delete reinterpret_cast<djinni::CppProxyHandle<::testsuite::ReturnTwo>*>(nativeRef);
+        delete reinterpret_cast<::djinni::CppProxyHandle<::testsuite::ReturnTwo>*>(nativeRef);
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 

--- a/test-suite/generated-src/jni/NativeReverseClientInterface.cpp
+++ b/test-suite/generated-src/jni/NativeReverseClientInterface.cpp
@@ -16,7 +16,7 @@ CJNIEXPORT void JNICALL Java_com_dropbox_djinni_test_ReverseClientInterface_0002
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
-        delete reinterpret_cast<djinni::CppProxyHandle<::testsuite::ReverseClientInterface>*>(nativeRef);
+        delete reinterpret_cast<::djinni::CppProxyHandle<::testsuite::ReverseClientInterface>*>(nativeRef);
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 

--- a/test-suite/generated-src/jni/NativeTestDuration.cpp
+++ b/test-suite/generated-src/jni/NativeTestDuration.cpp
@@ -16,7 +16,7 @@ CJNIEXPORT void JNICALL Java_com_dropbox_djinni_test_TestDuration_00024CppProxy_
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
-        delete reinterpret_cast<djinni::CppProxyHandle<::testsuite::TestDuration>*>(nativeRef);
+        delete reinterpret_cast<::djinni::CppProxyHandle<::testsuite::TestDuration>*>(nativeRef);
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 

--- a/test-suite/generated-src/jni/NativeTestHelpers.cpp
+++ b/test-suite/generated-src/jni/NativeTestHelpers.cpp
@@ -23,7 +23,7 @@ CJNIEXPORT void JNICALL Java_com_dropbox_djinni_test_TestHelpers_00024CppProxy_n
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
-        delete reinterpret_cast<djinni::CppProxyHandle<::testsuite::TestHelpers>*>(nativeRef);
+        delete reinterpret_cast<::djinni::CppProxyHandle<::testsuite::TestHelpers>*>(nativeRef);
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 

--- a/test-suite/generated-src/jni/NativeUserToken.cpp
+++ b/test-suite/generated-src/jni/NativeUserToken.cpp
@@ -27,7 +27,7 @@ CJNIEXPORT void JNICALL Java_com_dropbox_djinni_test_UserToken_00024CppProxy_nat
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
-        delete reinterpret_cast<djinni::CppProxyHandle<::testsuite::UserToken>*>(nativeRef);
+        delete reinterpret_cast<::djinni::CppProxyHandle<::testsuite::UserToken>*>(nativeRef);
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 

--- a/test-suite/generated-src/jni/NativeUsesSingleLanguageListeners.cpp
+++ b/test-suite/generated-src/jni/NativeUsesSingleLanguageListeners.cpp
@@ -36,7 +36,7 @@ CJNIEXPORT void JNICALL Java_com_dropbox_djinni_test_UsesSingleLanguageListeners
 {
     try {
         DJINNI_FUNCTION_PROLOGUE1(jniEnv, nativeRef);
-        delete reinterpret_cast<djinni::CppProxyHandle<::testsuite::UsesSingleLanguageListeners>*>(nativeRef);
+        delete reinterpret_cast<::djinni::CppProxyHandle<::testsuite::UsesSingleLanguageListeners>*>(nativeRef);
     } JNI_TRANSLATE_EXCEPTIONS_RETURN(jniEnv, )
 }
 


### PR DESCRIPTION
The Compiler had some issues finding the CppProxy, cause we were using foobar::djinni as namespace for generated djinni files. I changed in the JNIGenerator.scala file the namespace for the CppProxy to the global Namespace. Then the compiler could find the CppProxy and everything was alright for us.

The Problem was during compiling for Android with NDK r11b and the shipped clang compiler 3.6.