### PR TITLE
Cleaner fix for VS2015

### DIFF
--- a/support-lib/djinni_common.hpp
+++ b/support-lib/djinni_common.hpp
@@ -16,8 +16,18 @@
 
 #pragma once
 
-#ifdef _MSC_VER // weak attribute not supported by MSVC
-#define DJINNI_WEAK_DEFINITION
+#ifdef _MSC_VER
+    #define DJINNI_WEAK_DEFINITION // weak attribute not supported by MSVC
+    #define DJINNI_NORETURN_DEFINITION __declspec(noreturn)
+    #if _MSC_VER < 1900 // snprintf not implemented prior to VS2015
+        #define DJINNI_SNPRINTF snprintf
+        #define noexcept _NOEXCEPT // work-around for missing noexcept VS2015
+        #define constexpr // work-around for missing constexpr VS2015
+    #else
+        #define DJINNI_SNPRINTF _snprintf
+    #endif
 #else
-#define DJINNI_WEAK_DEFINITION __attribute__((weak))
+    #define DJINNI_WEAK_DEFINITION __attribute__((weak))
+    #define DJINNI_NORETURN_DEFINITION __attribute__((noreturn))
+    #define DJINNI_SNPRINTF snprintf
 #endif

--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -113,7 +113,8 @@ void jniExceptionCheck(JNIEnv * env) {
     }
 }
 
-DJINNI_WEAK_DEFINITION __attribute__((noreturn))
+DJINNI_WEAK_DEFINITION
+DJINNI_NORETURN_DEFINITION
 void jniThrowCppFromJavaException(JNIEnv * env, jthrowable java_exception) {
     throw jni_exception { env, java_exception };
 }
@@ -154,12 +155,7 @@ void jniThrowAssertionError(JNIEnv * env, const char * file, int line, const cha
     const char * file_basename = slash ? slash + 1 : file;
 
     char buf[256];
-#if (defined _MSC_VER) && (_MSC_VER < 1900)
-    // snprintf not implemented on MSVC prior to 2015
-    _snprintf(buf, sizeof buf, "djinni (%s:%d): %s", file_basename, line, check);
-#else
-    snprintf(buf, sizeof buf, "djinni (%s:%d): %s", file_basename, line, check);
-#endif
+    DJINNI_SNPRINTF(buf, sizeof buf, "djinni (%s:%d): %s", file_basename, line, check);
 
     const jclass cassert = env->FindClass("java/lang/Error");
     assert(cassert);

--- a/support-lib/jni/djinni_support.hpp
+++ b/support-lib/jni/djinni_support.hpp
@@ -24,13 +24,8 @@
 #include <unordered_map>
 
 #include "../proxy_cache_interface.hpp"
+#include "../djinni_common.hpp"
 #include <jni.h>
-
-// work-around for missing noexcept and constexpr support in MSVC prior to 2015
-#if (defined _MSC_VER) && (_MSC_VER < 1900)
-#  define noexcept _NOEXCEPT
-#  define constexpr
-#endif
 
 /*
  * Djinni support library
@@ -150,17 +145,13 @@ void jniExceptionCheck(JNIEnv * env);
  * can replace it by defining your own version.  The default implementation
  * will throw a jni_exception containing the given jthrowable.
  */
-__attribute__((noreturn))
+DJINNI_NORETURN_DEFINITION
 void jniThrowCppFromJavaException(JNIEnv * env, jthrowable java_exception);
 
 /*
  * Set an AssertionError in env with message message, and then throw via jniExceptionCheck.
  */
-#ifdef _MSC_VER
-  __declspec(noreturn)
-#else
-  __attribute__((noreturn))
-#endif
+DJINNI_NORETURN_DEFINITION
 void jniThrowAssertionError(JNIEnv * env, const char * file, int line, const char * check);
 
 #define DJINNI_ASSERT_MSG(check, env, message) \


### PR DESCRIPTION
I added and used more macros in djinni_common for hiding VS2015 limitations, instead of having several #ifdef _MSC_VER everywhere