### PR TITLE
Fix missing full declarations in IOS files

### DIFF
--- a/src/source/CppMarshal.scala
+++ b/src/source/CppMarshal.scala
@@ -72,11 +72,10 @@ class CppMarshal(spec: Spec) extends Marshal(spec) {
         }
       case DEnum =>
         if (d.name != exclude) {
-          if (forwardDeclareOnly) {
-            List(DeclRef(s"enum class ${typename(d.name, d.body)};", Some(spec.cppNamespace)))
-          } else {
-            List(ImportRef(include(d.name)))
-          }
+          // out enums might be used in Map or Set, which requires to be fully aware about the enum type
+          // so we cannot use forward declarations in this case, otherwise interfaces with std::unordered_map
+          // or std::unordered_set will not compile (e.g. the Objc djinni generated mm files)
+          List(ImportRef(include(d.name)))
         } else {
           List()
         }


### PR DESCRIPTION
This patch fixes issue when djinni defined Enum class
was used in some djinni interface, as a key attribute for map or set.
In those cases IOS generated *.mm files were not able to be compiled
without modification of djinni generated content.

In order to fix it the only easy way is to disable forward declarations
for djinni enum types, and use only full header include instead. The hard
and more optimal way would be to extend the djinni with checking if the enum
is actually used by map or set within the interface and include the header file
only then, but that seems to be major refactoring.
