### PR TITLE
Fixed crash

### DIFF
--- a/src/source/Main.scala
+++ b/src/source/Main.scala
@@ -241,7 +241,8 @@ object Main {
     // Parse IDL file.
     System.out.println("Parsing...")
     val inFileListWriter = if (inFileListPath.isDefined) {
-      createFolder("input file list", inFileListPath.get.getParentFile)
+      if (inFileListPath.get.getParentFile != null)
+        createFolder("input file list", inFileListPath.get.getParentFile)
       Some(new BufferedWriter(new FileWriter(inFileListPath.get)))
     } else {
       None
@@ -271,7 +272,8 @@ object Main {
 
     System.out.println("Generating...")
     val outFileListWriter = if (outFileListPath.isDefined) {
-      createFolder("output file list", outFileListPath.get.getParentFile)
+      if (outFileListPath.get.getParentFile != null)
+        createFolder("output file list", outFileListPath.get.getParentFile)
       Some(new BufferedWriter(new FileWriter(outFileListPath.get)))
     } else {
       None


### PR DESCRIPTION
Djinni crashes if the options "--in-file-list ' and '--out-file-list" contains only the file names. If the path contains the folder name, the program does not crash.

For example:

>> djinni --idl test.djinni --list-out-files somefile.txt
Already up to date: Djinni
Parsing...
Resolving...
Generating...
Exception in thread "main" java.lang.NullPointerException
	at djinni.generatorTools.package$.createFolder(generator.scala:172)
	at djinni.Main$.main(Main.scala:275)
	at djinni.Main.main(Main.scala)

if the path to explicitly specify a folder, then everything is OK:

>> djinni --idl test.djinni --list-out-files ./somefile.txt
Already up to date: Djinni
Parsing...
Resolving...
Generating...