### PR TITLE
Generating constexpr for constants when possible

### DIFF
--- a/test-suite/generated-src/cpp/constants.cpp
+++ b/test-suite/generated-src/cpp/constants.cpp
@@ -5,34 +5,6 @@
 
 namespace testsuite {
 
-bool const Constants::BOOL_CONSTANT = true;
-
-int8_t const Constants::I8_CONSTANT = 1;
-
-int16_t const Constants::I16_CONSTANT = 2;
-
-int32_t const Constants::I32_CONSTANT = 3;
-
-int64_t const Constants::I64_CONSTANT = 4;
-
-float const Constants::F32_CONSTANT = 5.0f;
-
-double const Constants::F64_CONSTANT = 5.0;
-
-std::experimental::optional<bool> const Constants::OPT_BOOL_CONSTANT = true;
-
-std::experimental::optional<int8_t> const Constants::OPT_I8_CONSTANT = 1;
-
-std::experimental::optional<int16_t> const Constants::OPT_I16_CONSTANT = 2;
-
-std::experimental::optional<int32_t> const Constants::OPT_I32_CONSTANT = 3;
-
-std::experimental::optional<int64_t> const Constants::OPT_I64_CONSTANT = 4;
-
-std::experimental::optional<float> const Constants::OPT_F32_CONSTANT = 5.0;
-
-std::experimental::optional<double> const Constants::OPT_F64_CONSTANT = 5.0;
-
 std::string const Constants::STRING_CONSTANT = {"string-constant"};
 
 std::experimental::optional<std::string> const Constants::OPT_STRING_CONSTANT = {"string-constant"};
@@ -40,7 +12,5 @@ std::experimental::optional<std::string> const Constants::OPT_STRING_CONSTANT = 
 ConstantRecord const Constants::OBJECT_CONSTANT = ConstantRecord(
     Constants::I32_CONSTANT /* some_integer */ ,
     Constants::STRING_CONSTANT /* some_string */ );
-
-bool const Constants::DUMMY = false;
 
 }  // namespace testsuite

--- a/test-suite/generated-src/cpp/constants.hpp
+++ b/test-suite/generated-src/cpp/constants.hpp
@@ -15,57 +15,41 @@ namespace testsuite {
 struct Constants final {
 
     /** bool_constant has documentation. */
-    static bool const BOOL_CONSTANT;
-
-    static int8_t const I8_CONSTANT;
-
-    static int16_t const I16_CONSTANT;
-
-    static int32_t const I32_CONSTANT;
-
-    static int64_t const I64_CONSTANT;
-
-    static float const F32_CONSTANT;
-
+    static constexpr const bool BOOL_CONSTANT = { true };
+    static constexpr const int8_t I8_CONSTANT = { 1 };
+    static constexpr const int16_t I16_CONSTANT = { 2 };
+    static constexpr const int32_t I32_CONSTANT = { 3 };
+    static constexpr const int64_t I64_CONSTANT = { 4 };
+    static constexpr const float F32_CONSTANT = { 5.0f };
     /**
      * f64_constant has long documentation.
      * (Second line of multi-line documentation.
      *   Indented third line of multi-line documentation.)
      */
-    static double const F64_CONSTANT;
-
-    static std::experimental::optional<bool> const OPT_BOOL_CONSTANT;
-
-    static std::experimental::optional<int8_t> const OPT_I8_CONSTANT;
-
+    static constexpr const double F64_CONSTANT = { 5.0 };
+    static constexpr const std::experimental::optional<bool> OPT_BOOL_CONSTANT = { true };
+    static constexpr const std::experimental::optional<int8_t> OPT_I8_CONSTANT = { 1 };
     /** opt_i16_constant has documentation. */
-    static std::experimental::optional<int16_t> const OPT_I16_CONSTANT;
-
-    static std::experimental::optional<int32_t> const OPT_I32_CONSTANT;
-
-    static std::experimental::optional<int64_t> const OPT_I64_CONSTANT;
-
+    static constexpr const std::experimental::optional<int16_t> OPT_I16_CONSTANT = { 2 };
+    static constexpr const std::experimental::optional<int32_t> OPT_I32_CONSTANT = { 3 };
+    static constexpr const std::experimental::optional<int64_t> OPT_I64_CONSTANT = { 4 };
     /**
      * opt_f32_constant has long documentation.
      * (Second line of multi-line documentation.
      *   Indented third line of multi-line documentation.)
      */
-    static std::experimental::optional<float> const OPT_F32_CONSTANT;
-
-    static std::experimental::optional<double> const OPT_F64_CONSTANT;
-
-    static std::string const STRING_CONSTANT;
-
-    static std::experimental::optional<std::string> const OPT_STRING_CONSTANT;
-
-    static ConstantRecord const OBJECT_CONSTANT;
-
+    static constexpr const std::experimental::optional<float> OPT_F32_CONSTANT = { 5.0 };
+    static constexpr const std::experimental::optional<double> OPT_F64_CONSTANT = { 5.0 };
+    static  const std::string STRING_CONSTANT;
+    static  const std::experimental::optional<std::string> OPT_STRING_CONSTANT;
+    static  const ConstantRecord OBJECT_CONSTANT;
     /**
      * No support for null optional constants
      * No support for optional constant records
      * No support for constant binary, list, set, map
      */
-    static bool const DUMMY;
+    static constexpr const bool DUMMY = { false };
+
 };
 
 }  // namespace testsuite

--- a/test-suite/generated-src/cpp/constants_interface.cpp
+++ b/test-suite/generated-src/cpp/constants_interface.cpp
@@ -6,34 +6,6 @@
 
 namespace testsuite {
 
-bool const ConstantsInterface::BOOL_CONSTANT = true;
-
-int8_t const ConstantsInterface::I8_CONSTANT = 1;
-
-int16_t const ConstantsInterface::I16_CONSTANT = 2;
-
-int32_t const ConstantsInterface::I32_CONSTANT = 3;
-
-int64_t const ConstantsInterface::I64_CONSTANT = 4;
-
-float const ConstantsInterface::F32_CONSTANT = 5.0f;
-
-double const ConstantsInterface::F64_CONSTANT = 5.0;
-
-std::experimental::optional<bool> const ConstantsInterface::OPT_BOOL_CONSTANT = true;
-
-std::experimental::optional<int8_t> const ConstantsInterface::OPT_I8_CONSTANT = 1;
-
-std::experimental::optional<int16_t> const ConstantsInterface::OPT_I16_CONSTANT = 2;
-
-std::experimental::optional<int32_t> const ConstantsInterface::OPT_I32_CONSTANT = 3;
-
-std::experimental::optional<int64_t> const ConstantsInterface::OPT_I64_CONSTANT = 4;
-
-std::experimental::optional<float> const ConstantsInterface::OPT_F32_CONSTANT = 5.0;
-
-std::experimental::optional<double> const ConstantsInterface::OPT_F64_CONSTANT = 5.0;
-
 std::string const ConstantsInterface::STRING_CONSTANT = {"string-constant"};
 
 std::experimental::optional<std::string> const ConstantsInterface::OPT_STRING_CONSTANT = {"string-constant"};

--- a/test-suite/generated-src/cpp/constants_interface.hpp
+++ b/test-suite/generated-src/cpp/constants_interface.hpp
@@ -16,51 +16,36 @@ class ConstantsInterface {
 public:
     virtual ~ConstantsInterface() {}
 
-    static bool const BOOL_CONSTANT;
-
-    static int8_t const I8_CONSTANT;
-
-    static int16_t const I16_CONSTANT;
-
+    static constexpr const bool BOOL_CONSTANT = { true };
+    static constexpr const int8_t I8_CONSTANT = { 1 };
+    static constexpr const int16_t I16_CONSTANT = { 2 };
     /** i32_constant has documentation. */
-    static int32_t const I32_CONSTANT;
-
+    static constexpr const int32_t I32_CONSTANT = { 3 };
     /**
      * i64_constant has long documentation.
      * (Second line of multi-line documentation.
      *   Indented third line of multi-line documentation.)
      */
-    static int64_t const I64_CONSTANT;
-
-    static float const F32_CONSTANT;
-
-    static double const F64_CONSTANT;
-
-    static std::experimental::optional<bool> const OPT_BOOL_CONSTANT;
-
-    static std::experimental::optional<int8_t> const OPT_I8_CONSTANT;
-
+    static constexpr const int64_t I64_CONSTANT = { 4 };
+    static constexpr const float F32_CONSTANT = { 5.0f };
+    static constexpr const double F64_CONSTANT = { 5.0 };
+    static constexpr const std::experimental::optional<bool> OPT_BOOL_CONSTANT = { true };
+    static constexpr const std::experimental::optional<int8_t> OPT_I8_CONSTANT = { 1 };
     /** opt_i16_constant has documentation. */
-    static std::experimental::optional<int16_t> const OPT_I16_CONSTANT;
-
-    static std::experimental::optional<int32_t> const OPT_I32_CONSTANT;
-
-    static std::experimental::optional<int64_t> const OPT_I64_CONSTANT;
-
+    static constexpr const std::experimental::optional<int16_t> OPT_I16_CONSTANT = { 2 };
+    static constexpr const std::experimental::optional<int32_t> OPT_I32_CONSTANT = { 3 };
+    static constexpr const std::experimental::optional<int64_t> OPT_I64_CONSTANT = { 4 };
     /**
      * opt_f32_constant has long documentation.
      * (Second line of multi-line documentation.
      *   Indented third line of multi-line documentation.)
      */
-    static std::experimental::optional<float> const OPT_F32_CONSTANT;
+    static constexpr const std::experimental::optional<float> OPT_F32_CONSTANT = { 5.0 };
+    static constexpr const std::experimental::optional<double> OPT_F64_CONSTANT = { 5.0 };
+    static  const std::string STRING_CONSTANT;
+    static  const std::experimental::optional<std::string> OPT_STRING_CONSTANT;
+    static  const ConstantRecord OBJECT_CONSTANT;
 
-    static std::experimental::optional<double> const OPT_F64_CONSTANT;
-
-    static std::string const STRING_CONSTANT;
-
-    static std::experimental::optional<std::string> const OPT_STRING_CONSTANT;
-
-    static ConstantRecord const OBJECT_CONSTANT;
 
     /**
      * No support for null optional constants

--- a/test-suite/generated-src/cpp/extended_record_base.hpp
+++ b/test-suite/generated-src/cpp/extended_record_base.hpp
@@ -12,7 +12,8 @@ struct ExtendedRecord; // Requiring extended class
 /** Extended record */
 struct ExtendedRecordBase {
 
-    static ExtendedRecord const EXTENDED_RECORD_CONST;
+    static  const ExtendedRecord EXTENDED_RECORD_CONST;
+
     bool foo;
 
     ExtendedRecordBase(bool foo_)

--- a/test-suite/generated-src/cpp/interface_using_extended_record.hpp
+++ b/test-suite/generated-src/cpp/interface_using_extended_record.hpp
@@ -12,7 +12,8 @@ class InterfaceUsingExtendedRecord {
 public:
     virtual ~InterfaceUsingExtendedRecord() {}
 
-    static RecordUsingExtendedRecord const CR;
+    static  const RecordUsingExtendedRecord CR;
+
 
     virtual ExtendedRecord meth(const ExtendedRecord & er) = 0;
 };

--- a/test-suite/generated-src/cpp/record_using_extended_record.hpp
+++ b/test-suite/generated-src/cpp/record_using_extended_record.hpp
@@ -10,7 +10,8 @@ namespace testsuite {
 
 struct RecordUsingExtendedRecord final {
 
-    static RecordUsingExtendedRecord const CR;
+    static  const RecordUsingExtendedRecord CR;
+
     ExtendedRecord er;
 
     RecordUsingExtendedRecord(ExtendedRecord er_)


### PR DESCRIPTION
I've noticed that the constants in generated C++ code are always initialized in the cpp file, even for basic types like bool and numerics.

In this patch I've modified the C++ code generator to determine if a value can be initialized in the header and, if so, place it there as a constexpr. This only happens for bools, numerics, enums and optionals thereof. If any other kind of constant is present, its value will get set in the implementation file as before.

Please refer to the "generated-src" from the test suite which is part of this commit.