### PR TITLE
Set minimum compatible IDEA API version to 139.

### DIFF
--- a/intellij-plugin/META-INF/plugin.xml
+++ b/intellij-plugin/META-INF/plugin.xml
@@ -29,7 +29,7 @@
   </change-notes>
 
   <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-  <idea-version since-build="131"/>
+  <idea-version since-build="139"/>
 
   <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
        on how to target different products -->


### PR DESCRIPTION
 The plugin does not work with 131 only as it is missing some API class(es).
Api Level 139 is supported by IDEA 14+, Android Studio 1.3+, AppCode 3.3+ and PyCharm 4+. (Only verified IDEA 14 & AppCode 3.3, the rest are taken from http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html ) 