### PR TITLE
Update ios version in Make targets to 10.1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ example_ios: ./build_ios/example/libtextsort.xcodeproj
            -scheme TextSort \
            -configuration 'Debug' \
            -sdk iphonesimulator \
-	   -destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3'
+	   -destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.1'
 
 # this target implicitly depends on GypAndroid.mk since gradle will try to make it
 example_android: GypAndroid.mk

--- a/test-suite/Makefile
+++ b/test-suite/Makefile
@@ -6,7 +6,7 @@ djinni:
 	./run_djinni.sh
 
 objc: djinni
-	cd objc; xcodebuild -sdk iphonesimulator -project DjinniObjcTest.xcodeproj -scheme DjinniObjcTest test -destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3'
+	cd objc; xcodebuild -sdk iphonesimulator -project DjinniObjcTest.xcodeproj -scheme DjinniObjcTest test -destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.1'
 
 java: djinni
 	cd java && ant compile test


### PR DESCRIPTION
From the Slack discussion channel: https://mobilecpp.slack.com/archives/general/p1478766914000338

In short, the Makefiles say that the iOS targets need to run on a simulator that's running ios 9.3, which causes the iOS targets to fail if you have the latest version of Xcode installed. This change updates the Makefiles to specify ios 10.1.