### PR TITLE
fixing error from clang (issue #294)

### DIFF
--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -482,7 +482,7 @@ std::string jniUTF8FromString(JNIEnv * env, const jstring jstr) {
 }
 
 template<int wcharTypeSize>
-static std::wstring implUTF16ToWString(const char16_t * data, size_t length)
+static std::wstring implUTF16ToWString(const char16_t * /*data*/, size_t /*length*/)
 {
     static_assert(wcharTypeSize == 2 || wcharTypeSize == 4, "wchar_t must be represented by UTF-16 or UTF-32 encoding");
     return {}; // unreachable


### PR DESCRIPTION
  djinni_support.cpp:485: error: unused parameter