### PR TITLE
Removing of unnecessary objc files generation

### DIFF
--- a/src/source/ObjcppGenerator.scala
+++ b/src/source/ObjcppGenerator.scala
@@ -62,6 +62,11 @@ class ObjcppGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
   def nnCheck(expr: String): String = spec.cppNnCheckExpression.fold(expr)(check => s"$check($expr)")
 
   override def generateInterface(origin: String, ident: Ident, doc: Doc, typeParams: Seq[TypeParam], i: Interface) {
+    if (!i.ext.objc && !i.ext.cpp) {
+      // there is no point of generating interface if it is not expected to be used by OBJC nor CPP
+      return
+    }
+
     val refs = new ObjcRefs()
     i.methods.map(m => {
       m.params.map(p => refs.find(p.ty))


### PR DESCRIPTION
This patch removes the unnecessary generation of ObjcppGenerator files related to interfaces, which are not meant to be implemented within OBJC nor CPP. These files were generated even wrongly as the generator expects that at least one side and generated code was not able to be compiled properly due to missing references etc...

Example of such interface:
```
MyInterface = interface +j {
  MyMethod1();
}
```