### PR TITLE
Cppfixes 201704

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,8 @@
+The following is a partial list of individuals or corporations
+who have identified their contributions to the djinni project.
+
+The complete list of contributors can be identified through
+Git history.
+
+- Google Inc.
+

--- a/README.md
+++ b/README.md
@@ -437,9 +437,6 @@ Run `make test` to invoke the test suite, found in the test-suite subdirectory. 
 - Iulia Tamas
 - Andrew Twyman
 
-## Contributors
-- Google Inc.
-
 ## Contacts
 - Andrew Twyman - `atwyman@dropbox.com`
 - Jacob Potter - `djinni@j4cbo.com`

--- a/README.md
+++ b/README.md
@@ -437,6 +437,9 @@ Run `make test` to invoke the test suite, found in the test-suite subdirectory. 
 - Iulia Tamas
 - Andrew Twyman
 
+## Contributors
+- Google Inc.
+
 ## Contacts
 - Andrew Twyman - `atwyman@dropbox.com`
 - Jacob Potter - `djinni@j4cbo.com`

--- a/support-lib/jni/djinni_support.hpp
+++ b/support-lib/jni/djinni_support.hpp
@@ -340,6 +340,8 @@ template <class T>
 static const std::shared_ptr<T> & objectFromHandleAddress(jlong handle) {
     assert(handle);
     assert(handle > 4096);
+    // Below line segfaults gcc-4.8. Using a temporary variable hides the bug.
+    //const auto & ret = reinterpret_cast<const CppProxyHandle<T> *>(handle)->get();
     const CppProxyHandle<T> *temp = reinterpret_cast<const CppProxyHandle<T> *>(handle);
     const auto & ret = temp->get();
     assert(ret);

--- a/support-lib/jni/djinni_support.hpp
+++ b/support-lib/jni/djinni_support.hpp
@@ -156,11 +156,11 @@ void jniThrowAssertionError(JNIEnv * env, const char * file, int line, const cha
 
 #define DJINNI_ASSERT_MSG(check, env, message) \
     do { \
-        djinni::jniExceptionCheck(env); \
+        ::djinni::jniExceptionCheck(env); \
         const bool check__res = bool(check); \
-        djinni::jniExceptionCheck(env); \
+        ::djinni::jniExceptionCheck(env); \
         if (!check__res) { \
-            djinni::jniThrowAssertionError(env, __FILE__, __LINE__, message); \
+            ::djinni::jniThrowAssertionError(env, __FILE__, __LINE__, message); \
         } \
     } while(false)
 #define DJINNI_ASSERT(check, env) DJINNI_ASSERT_MSG(check, env, #check)
@@ -340,7 +340,8 @@ template <class T>
 static const std::shared_ptr<T> & objectFromHandleAddress(jlong handle) {
     assert(handle);
     assert(handle > 4096);
-    const auto & ret = reinterpret_cast<const CppProxyHandle<T> *>(handle)->get();
+    const CppProxyHandle<T> *temp = reinterpret_cast<const CppProxyHandle<T> *>(handle);
+    const auto & ret = temp->get();
     assert(ret);
     return ret;
 }

--- a/support-lib/jni/djinni_support.hpp
+++ b/support-lib/jni/djinni_support.hpp
@@ -342,8 +342,9 @@ static const std::shared_ptr<T> & objectFromHandleAddress(jlong handle) {
     assert(handle > 4096);
     // Below line segfaults gcc-4.8. Using a temporary variable hides the bug.
     //const auto & ret = reinterpret_cast<const CppProxyHandle<T> *>(handle)->get();
-    const CppProxyHandle<T> *temp = reinterpret_cast<const CppProxyHandle<T> *>(handle);
-    const auto & ret = temp->get();
+    const CppProxyHandle<T> *proxy_handle =
+        reinterpret_cast<const CppProxyHandle<T> *>(handle);
+    const auto & ret = proxy_handle->get();
     assert(ret);
     return ret;
 }

--- a/support-lib/proxy_cache_interface.hpp
+++ b/support-lib/proxy_cache_interface.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <memory>
 #include <functional>
 #include <typeindex>
 


### PR DESCRIPTION
Please consider the following changes - these fix build issues in our environment, and perhaps will help others.

- Adding :: to djinni namespace inside the DJINNI_ASSERT macros. This is already done in other macros in the file, and prevents a deeper namespace from being chosen inadvertently.
- proxy_cache_interface.hpp uses shared_ptr in a template class without including <memory>.
- Something about objectFromHandleAddress() is causing the compiler to segfault on the specified line. Not sure why (still investigating), but in the meantime, the temporary variable allows the compiler to complete.

Thanks!