### PR TITLE
[Android] Fix Djinni initialization crash in multi shared library case

### DIFF
--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -46,9 +46,9 @@ JniClassInitializer::registration_vec JniClassInitializer::get_all() {
     return get_vec();
 }
 
-JniClassInitializer::JniClassInitializer(const std::function<void()> & init) {
+JniClassInitializer::JniClassInitializer(std::function<void()> init) {
     const std::lock_guard<std::mutex> lock(get_mutex());
-    get_vec().emplace_back(init);
+    get_vec().push_back(std::move(init));
 }
 
 void jniInit(JavaVM * jvm) {

--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -45,14 +45,9 @@ JniClassInitializer::registration_vec JniClassInitializer::get_all() {
     return get_vec();
 }
 
-JniClassInitializer::JniClassInitializer(const std::function<void()> & init) : init(init) {
+JniClassInitializer::JniClassInitializer(const std::function<void()> & init) {
     const std::lock_guard<std::mutex> lock(get_mutex());
-    get_vec().emplace_back(this);
-}
-
-JniClassInitializer::~JniClassInitializer() {
-    const std::lock_guard<std::mutex> lock(get_mutex());
-    get_vec().erase(std::remove(get_vec().begin(), get_vec().end(), this), get_vec().end());
+    get_vec().emplace_back(init);
 }
 
 void jniInit(JavaVM * jvm) {
@@ -60,7 +55,7 @@ void jniInit(JavaVM * jvm) {
 
     try {
         for (const auto & initializer : JniClassInitializer::get_all()) {
-            initializer->init();
+            initializer();
         }
     } catch (const std::exception & e) {
         // Default exception handling only, since non-default might not be safe if init

--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -40,6 +40,7 @@ std::mutex & JniClassInitializer::get_mutex() {
     return mtx;
 }
 
+/*static*/
 JniClassInitializer::registration_vec JniClassInitializer::get_all() {
     const std::lock_guard<std::mutex> lock(get_mutex());
     return get_vec();

--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -28,29 +28,22 @@ namespace djinni {
 // Set only once from JNI_OnLoad before any other JNI calls, so no lock needed.
 static JavaVM * g_cachedJVM;
 
-JniClassInitializer::registration_set & JniClassInitializer::get_set() {
-    static JniClassInitializer::registration_set m;
-    return m;
-}
+/*static*/ JniClassInitializer::registration_vec JniClassInitializer::m_vec;
+/*static*/ std::mutex JniClassInitializer::m_mutex;
 
-std::mutex & JniClassInitializer::get_mutex() {
-    static std::mutex mtx;
-    return mtx;
-}
-
-JniClassInitializer::registration_set JniClassInitializer::get_all() {
-    const std::lock_guard<std::mutex> lock(get_mutex());
-    return get_set();
+JniClassInitializer::registration_vec JniClassInitializer::get_all() {
+    const std::lock_guard<std::mutex> lock(m_mutex);
+    return m_vec;
 }
 
 JniClassInitializer::JniClassInitializer(const std::function<void()> & init) : init(init){
-    const std::lock_guard<std::mutex> lock(get_mutex());
-    get_set().emplace(this);
+    const std::lock_guard<std::mutex> lock(m_mutex);
+    m_vec.emplace_back(this);
 }
 
 JniClassInitializer::~JniClassInitializer() {
-    const std::lock_guard<std::mutex> lock(get_mutex());
-    get_set().erase(this);
+    const std::lock_guard<std::mutex> lock(m_mutex);
+    m_vec.erase(std::remove(m_vec.begin(), m_vec.end(), this), m_vec.end());
 }
 
 void jniInit(JavaVM * jvm) {

--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -45,7 +45,7 @@ JniClassInitializer::registration_vec JniClassInitializer::get_all() {
     return get_vec();
 }
 
-JniClassInitializer::JniClassInitializer(const std::function<void()> & init) : init(init){
+JniClassInitializer::JniClassInitializer(const std::function<void()> & init) : init(init) {
     const std::lock_guard<std::mutex> lock(get_mutex());
     get_vec().emplace_back(this);
 }

--- a/support-lib/jni/djinni_support.hpp
+++ b/support-lib/jni/djinni_support.hpp
@@ -175,7 +175,7 @@ class JniClassInitializer {
 
 private:
 
-    JniClassInitializer(const std::function<void()> & init);
+    JniClassInitializer(std::function<void()> init);
 
     template <class C> friend class JniClass;
     friend void jniInit(JavaVM *);

--- a/support-lib/jni/djinni_support.hpp
+++ b/support-lib/jni/djinni_support.hpp
@@ -170,13 +170,13 @@ void jniThrowAssertionError(JNIEnv * env, const char * file, int line, const cha
  */
 class JniClassInitializer {
 
-    using registration_vec = std::vector<JniClassInitializer *>;
+    using registration_vec = std::vector<std::function<void()>>;
     static registration_vec get_all();
 
 private:
-    const std::function<void()> init;
+
     JniClassInitializer(const std::function<void()> & init);
-    ~JniClassInitializer();
+
     template <class C> friend class JniClass;
     friend void jniInit(JavaVM *);
 

--- a/support-lib/jni/djinni_support.hpp
+++ b/support-lib/jni/djinni_support.hpp
@@ -180,8 +180,8 @@ private:
     template <class C> friend class JniClass;
     friend void jniInit(JavaVM *);
 
-    static registration_vec m_vec;
-    static std::mutex m_mutex;
+    static registration_vec & get_vec();
+    static std::mutex       & get_mutex();
 };
 
 /*

--- a/support-lib/jni/djinni_support.hpp
+++ b/support-lib/jni/djinni_support.hpp
@@ -21,7 +21,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
-#include <unordered_set>
+#include <vector>
 
 #include "../proxy_cache_interface.hpp"
 #include "../djinni_common.hpp"
@@ -170,8 +170,8 @@ void jniThrowAssertionError(JNIEnv * env, const char * file, int line, const cha
  */
 class JniClassInitializer {
 
-    using registration_set = std::unordered_set<JniClassInitializer *>;
-    static registration_set get_all();
+    using registration_vec = std::vector<JniClassInitializer *>;
+    static registration_vec get_all();
 
 private:
     const std::function<void()> init;
@@ -180,8 +180,8 @@ private:
     template <class C> friend class JniClass;
     friend void jniInit(JavaVM *);
 
-    static registration_set & get_set();
-    static std::mutex       & get_mutex();
+    static registration_vec m_vec;
+    static std::mutex m_mutex;
 };
 
 /*


### PR DESCRIPTION
Fix Djinni initialization crash in multi shared library case (i.e. djinni_support_lib is a shared library used by other shared libraries).

Crash is observed in Android Studio 2.3 with NDK+cmake setup when hitting assert statement: 
```
class JniClass {
public:
    static const C & get() {
        (void)s_initializer;
        assert(s_singleton); // Crashes here
        return *s_singleton;
    }
```

My understanding of the problem is that static_registration class template header is included in two different translation units in the shared libs and so results in bad initialization of the JniClassInitializer map.

Explicit template specialization of static_registration<void *, const JniClassInitializer>::get_map() in the cpp file is a way to force that get_map method to a single translation unit and so enforce its singleton nature.

With the exact same code, init crash was observed on Android 5 but not on Android 6 (tested in both case on a Nexus 5). I have no idea why it's a problem with one Android version and not the other.