### PR TITLE
Avoid unused variable warning when compiling djinni_support.cpp

### DIFF
--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -58,7 +58,7 @@ void jniInit(JavaVM * jvm) {
         for (const auto & initializer : JniClassInitializer::get_all()) {
             initializer();
         }
-    } catch (const std::exception & e) {
+    } catch (const std::exception &) {
         // Default exception handling only, since non-default might not be safe if init
         // is incomplete.
         jniDefaultSetPendingFromCurrent(jniGetThreadEnv(), __func__);


### PR DESCRIPTION
This avoids the warning

```
/project/support-lib/jni/djinni_support.cpp:61:37: warning: unused exception parameter 'e' [-Wunused-exception-parameter]
    } catch (const std::exception & e) {
                                    ^
1 warning generated.
```