### PR TITLE
Python tooling issues

### DIFF
--- a/example/generated-src/cwrapper/dh__list_string.cpp
+++ b/example/generated-src/cwrapper/dh__list_string.cpp
@@ -32,9 +32,9 @@ void list_string_add_callback__get_size(size_t( * ptr)(DjinniObjectHandle *)) {
     s_py_callback_list_string__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_list_string__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_list_string__python_create)(void);
 
-void list_string_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void list_string_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_list_string__python_create = ptr;
 }
 

--- a/example/generated-src/cwrapper/dh__list_string.h
+++ b/example/generated-src/cwrapper/dh__list_string.h
@@ -9,5 +9,5 @@ void optional_list_string___delete(struct DjinniOptionalObjectHandle *);
 void list_string_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void list_string_add_callback__get_elem(struct DjinniString *( * ptr)(struct DjinniObjectHandle *, size_t));
 void list_string_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void list_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void list_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void list_string_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, struct DjinniString *));

--- a/example/run_py_example.sh
+++ b/example/run_py_example.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
-set -e
+set -eux
 
 # Locate the script file.  Cross symlinks if necessary.
 loc="$0"
@@ -16,8 +16,16 @@ base_dir=$(cd "`dirname "$loc"`" && pwd)
 
 python_cmd=$1
 
+export PYTHONPATH=${PYTHONPATH:-""}
 export PYTHONPATH="$base_dir/../support-lib/py:$base_dir/../build_py/cffi:$base_dir/generated-src/python:$PYTHONPATH"
-export DYLD_LIBRARY_PATH=$base_dir/../build_py/cffi:$DYLD_LIBRARY_PATH
-(cd "$base_dir/../build_py/cffi" \
+# The use of install_name_tool below is a hack to force MacOS to know where to load libtextsort_py.dylib,
+# needed because DYLD_LIBRARY_PATH is now ignored by System Integrity Protection.  A real installed which
+# used a dylib like this would need a cleaner solution based on @rpath or somesuch thing.  The file existence
+# checks before the commands look for the two different .so names produced for CPython 2 or 3.
+#export DYLD_LIBRARY_PATH=$base_dir/../build_py/cffi:$DYLD_LIBRARY_PATH
+cffi_dir=$(cd "$base_dir/../build_py/cffi" && pwd)
+(cd "$cffi_dir" \
         && "$python_cmd" ../../example/generated-src/cffi/pycffi_lib_build.py ../../support-lib/cwrapper/wrapper_marshal.h $(ls ../../example/generated-src/cwrapper/*.h) \
+        && echo && ([ ! -f PyCFFIlib_cffi.so ] || install_name_tool -change /usr/local/lib/libtextsort_py.dylib "$cffi_dir/libtextsort_py.dylib" PyCFFIlib_cffi.so) \
+        && echo && ([ ! -f PyCFFIlib_cffi.*.so ] || install_name_tool -change /usr/local/lib/libtextsort_py.dylib "$cffi_dir/libtextsort_py.dylib" PyCFFIlib_cffi.*.so) \
         && echo && "$python_cmd" ../../example/python/textsort.py)

--- a/example/run_py_example.sh
+++ b/example/run_py_example.sh
@@ -19,7 +19,7 @@ python_cmd=$1
 export PYTHONPATH=${PYTHONPATH:-""}
 export PYTHONPATH="$base_dir/../support-lib/py:$base_dir/../build_py/cffi:$base_dir/generated-src/python:$PYTHONPATH"
 # The use of install_name_tool below is a hack to force MacOS to know where to load libtextsort_py.dylib,
-# needed because DYLD_LIBRARY_PATH is now ignored by System Integrity Protection.  A real installed which
+# needed because DYLD_LIBRARY_PATH is now ignored by System Integrity Protection.  A real installed app which
 # used a dylib like this would need a cleaner solution based on @rpath or somesuch thing.  The file existence
 # checks before the commands look for the two different .so names produced for CPython 2 or 3.
 #export DYLD_LIBRARY_PATH=$base_dir/../build_py/cffi:$DYLD_LIBRARY_PATH

--- a/src/source/CWrapperGenerator.scala
+++ b/src/source/CWrapperGenerator.scala
@@ -268,7 +268,7 @@ class CWrapperGenerator(spec: Spec) extends Generator(spec) {
     declareGlobalGetter("__get_size", ret, cArgs, className, w)
 
     ret = "DjinniObjectHandle *"
-    cArgs = Seq("").mkString("(", ", ", ")")
+    cArgs = "(void)" // () in C means "unspecified args", so this avoids -Wstrict-prototypes
     declareGlobalGetter("__python_create", ret, cArgs, className, w)
 
     ret = "void"
@@ -293,7 +293,7 @@ class CWrapperGenerator(spec: Spec) extends Generator(spec) {
     declareGlobalGetterSignature("__get_size", ret, cArgs, className, w)
 
     ret = "struct DjinniObjectHandle *"
-    cArgs = Seq("").mkString("(", ", ", ")")
+    cArgs = "(void)" // () in C means "unspecified args", so this avoids -Wstrict-prototypes
     declareGlobalGetterSignature("__python_create", ret, cArgs, className, w)
 
     ret = "void"

--- a/support-lib/cwrapper/wrapper_marshal.h
+++ b/support-lib/cwrapper/wrapper_marshal.h
@@ -20,7 +20,7 @@ void _djinni_add_callback_create_py_from_cpp_exception(CreateExceptionFnPtr fct_
 typedef void (* DeleteExceptionFnPtr) (struct DjinniPythonExceptionHandle *);
 void _djinni_add_callback_exception___delete(DeleteExceptionFnPtr fct_ptr); // called in cpp
 
-struct DjinniPythonExceptionHandle * djinni_from_python_check_and_clear_exception(); // called in python
+struct DjinniPythonExceptionHandle * djinni_from_python_check_and_clear_exception(void); // called in python
 
 // Djinni Structs and Boxed Types and Optionals
 struct DjinniBoxedI8;

--- a/test-suite/generated-src/cwrapper/dh__list_binary.cpp
+++ b/test-suite/generated-src/cwrapper/dh__list_binary.cpp
@@ -50,9 +50,9 @@ void list_binary_add_callback__get_size(size_t( * ptr)(DjinniObjectHandle *)) {
     s_py_callback_list_binary__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_list_binary__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_list_binary__python_create)(void);
 
-void list_binary_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void list_binary_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_list_binary__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__list_binary.h
+++ b/test-suite/generated-src/cwrapper/dh__list_binary.h
@@ -11,5 +11,5 @@ void optional_list_binary___delete(struct DjinniOptionalObjectHandle *);
 void list_binary_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void list_binary_add_callback__get_elem(struct DjinniBinary *( * ptr)(struct DjinniObjectHandle *, size_t));
 void list_binary_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void list_binary_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void list_binary_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void list_binary_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, struct DjinniBinary *));

--- a/test-suite/generated-src/cwrapper/dh__list_date.cpp
+++ b/test-suite/generated-src/cwrapper/dh__list_date.cpp
@@ -50,9 +50,9 @@ void list_date_add_callback__get_size(size_t( * ptr)(DjinniObjectHandle *)) {
     s_py_callback_list_date__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_list_date__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_list_date__python_create)(void);
 
-void list_date_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void list_date_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_list_date__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__list_date.h
+++ b/test-suite/generated-src/cwrapper/dh__list_date.h
@@ -11,5 +11,5 @@ void optional_list_date___delete(struct DjinniOptionalObjectHandle *);
 void list_date_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void list_date_add_callback__get_elem(uint64_t( * ptr)(struct DjinniObjectHandle *, size_t));
 void list_date_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void list_date_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void list_date_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void list_date_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, uint64_t));

--- a/test-suite/generated-src/cwrapper/dh__list_enum_color.cpp
+++ b/test-suite/generated-src/cwrapper/dh__list_enum_color.cpp
@@ -37,9 +37,9 @@ void list_enum_color_add_callback__get_size(size_t( * ptr)(DjinniObjectHandle *)
     s_py_callback_list_enum_color__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_list_enum_color__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_list_enum_color__python_create)(void);
 
-void list_enum_color_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void list_enum_color_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_list_enum_color__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__list_enum_color.h
+++ b/test-suite/generated-src/cwrapper/dh__list_enum_color.h
@@ -9,5 +9,5 @@ void optional_list_enum_color___delete(struct DjinniOptionalObjectHandle *);
 void list_enum_color_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void list_enum_color_add_callback__get_elem(int( * ptr)(struct DjinniObjectHandle *, size_t));
 void list_enum_color_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void list_enum_color_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void list_enum_color_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void list_enum_color_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, int));

--- a/test-suite/generated-src/cwrapper/dh__list_int32_t.cpp
+++ b/test-suite/generated-src/cwrapper/dh__list_int32_t.cpp
@@ -50,9 +50,9 @@ void list_int32_t_add_callback__get_size(size_t( * ptr)(DjinniObjectHandle *)) {
     s_py_callback_list_int32_t__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_list_int32_t__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_list_int32_t__python_create)(void);
 
-void list_int32_t_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void list_int32_t_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_list_int32_t__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__list_int32_t.h
+++ b/test-suite/generated-src/cwrapper/dh__list_int32_t.h
@@ -11,5 +11,5 @@ void optional_list_int32_t___delete(struct DjinniOptionalObjectHandle *);
 void list_int32_t_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void list_int32_t_add_callback__get_elem(int32_t( * ptr)(struct DjinniObjectHandle *, size_t));
 void list_int32_t_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void list_int32_t_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void list_int32_t_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void list_int32_t_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, int32_t));

--- a/test-suite/generated-src/cwrapper/dh__list_int64_t.cpp
+++ b/test-suite/generated-src/cwrapper/dh__list_int64_t.cpp
@@ -32,9 +32,9 @@ void list_int64_t_add_callback__get_size(size_t( * ptr)(DjinniObjectHandle *)) {
     s_py_callback_list_int64_t__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_list_int64_t__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_list_int64_t__python_create)(void);
 
-void list_int64_t_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void list_int64_t_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_list_int64_t__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__list_int64_t.h
+++ b/test-suite/generated-src/cwrapper/dh__list_int64_t.h
@@ -11,5 +11,5 @@ void optional_list_int64_t___delete(struct DjinniOptionalObjectHandle *);
 void list_int64_t_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void list_int64_t_add_callback__get_elem(int64_t( * ptr)(struct DjinniObjectHandle *, size_t));
 void list_int64_t_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void list_int64_t_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void list_int64_t_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void list_int64_t_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, int64_t));

--- a/test-suite/generated-src/cwrapper/dh__list_list_string.cpp
+++ b/test-suite/generated-src/cwrapper/dh__list_list_string.cpp
@@ -50,9 +50,9 @@ void list_list_string_add_callback__get_size(size_t( * ptr)(DjinniObjectHandle *
     s_py_callback_list_list_string__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_list_list_string__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_list_list_string__python_create)(void);
 
-void list_list_string_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void list_list_string_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_list_list_string__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__list_list_string.h
+++ b/test-suite/generated-src/cwrapper/dh__list_list_string.h
@@ -11,5 +11,5 @@ void optional_list_list_string___delete(struct DjinniOptionalObjectHandle *);
 void list_list_string_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void list_list_string_add_callback__get_elem(struct DjinniObjectHandle *( * ptr)(struct DjinniObjectHandle *, size_t));
 void list_list_string_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void list_list_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void list_list_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void list_list_string_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, struct DjinniObjectHandle *));

--- a/test-suite/generated-src/cwrapper/dh__list_map_string_int64_t.cpp
+++ b/test-suite/generated-src/cwrapper/dh__list_map_string_int64_t.cpp
@@ -33,9 +33,9 @@ void list_map_string_int64_t_add_callback__get_size(size_t( * ptr)(DjinniObjectH
     s_py_callback_list_map_string_int64_t__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_list_map_string_int64_t__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_list_map_string_int64_t__python_create)(void);
 
-void list_map_string_int64_t_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void list_map_string_int64_t_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_list_map_string_int64_t__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__list_map_string_int64_t.h
+++ b/test-suite/generated-src/cwrapper/dh__list_map_string_int64_t.h
@@ -11,5 +11,5 @@ void optional_list_map_string_int64_t___delete(struct DjinniOptionalObjectHandle
 void list_map_string_int64_t_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void list_map_string_int64_t_add_callback__get_elem(struct DjinniObjectHandle *( * ptr)(struct DjinniObjectHandle *, size_t));
 void list_map_string_int64_t_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void list_map_string_int64_t_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void list_map_string_int64_t_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void list_map_string_int64_t_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, struct DjinniObjectHandle *));

--- a/test-suite/generated-src/cwrapper/dh__list_optional_binary.cpp
+++ b/test-suite/generated-src/cwrapper/dh__list_optional_binary.cpp
@@ -50,9 +50,9 @@ void list_optional_binary_add_callback__get_size(size_t( * ptr)(DjinniObjectHand
     s_py_callback_list_optional_binary__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_list_optional_binary__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_list_optional_binary__python_create)(void);
 
-void list_optional_binary_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void list_optional_binary_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_list_optional_binary__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__list_optional_binary.h
+++ b/test-suite/generated-src/cwrapper/dh__list_optional_binary.h
@@ -11,5 +11,5 @@ void optional_list_optional_binary___delete(struct DjinniOptionalObjectHandle *)
 void list_optional_binary_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void list_optional_binary_add_callback__get_elem(struct DjinniBinary *( * ptr)(struct DjinniObjectHandle *, size_t));
 void list_optional_binary_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void list_optional_binary_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void list_optional_binary_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void list_optional_binary_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, struct DjinniBinary *));

--- a/test-suite/generated-src/cwrapper/dh__list_record_foo_some_other_record.cpp
+++ b/test-suite/generated-src/cwrapper/dh__list_record_foo_some_other_record.cpp
@@ -50,9 +50,9 @@ void list_record_foo_some_other_record_add_callback__get_size(size_t( * ptr)(Dji
     s_py_callback_list_record_foo_some_other_record__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_list_record_foo_some_other_record__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_list_record_foo_some_other_record__python_create)(void);
 
-void list_record_foo_some_other_record_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void list_record_foo_some_other_record_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_list_record_foo_some_other_record__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__list_record_foo_some_other_record.h
+++ b/test-suite/generated-src/cwrapper/dh__list_record_foo_some_other_record.h
@@ -11,5 +11,5 @@ void optional_list_record_foo_some_other_record___delete(struct DjinniOptionalOb
 void list_record_foo_some_other_record_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void list_record_foo_some_other_record_add_callback__get_elem(struct DjinniRecordHandle *( * ptr)(struct DjinniObjectHandle *, size_t));
 void list_record_foo_some_other_record_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void list_record_foo_some_other_record_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void list_record_foo_some_other_record_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void list_record_foo_some_other_record_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, struct DjinniRecordHandle *));

--- a/test-suite/generated-src/cwrapper/dh__list_set_string.cpp
+++ b/test-suite/generated-src/cwrapper/dh__list_set_string.cpp
@@ -33,9 +33,9 @@ void list_set_string_add_callback__get_size(size_t( * ptr)(DjinniObjectHandle *)
     s_py_callback_list_set_string__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_list_set_string__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_list_set_string__python_create)(void);
 
-void list_set_string_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void list_set_string_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_list_set_string__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__list_set_string.h
+++ b/test-suite/generated-src/cwrapper/dh__list_set_string.h
@@ -9,5 +9,5 @@ void optional_list_set_string___delete(struct DjinniOptionalObjectHandle *);
 void list_set_string_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void list_set_string_add_callback__get_elem(struct DjinniObjectHandle *( * ptr)(struct DjinniObjectHandle *, size_t));
 void list_set_string_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void list_set_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void list_set_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void list_set_string_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, struct DjinniObjectHandle *));

--- a/test-suite/generated-src/cwrapper/dh__list_string.cpp
+++ b/test-suite/generated-src/cwrapper/dh__list_string.cpp
@@ -50,9 +50,9 @@ void list_string_add_callback__get_size(size_t( * ptr)(DjinniObjectHandle *)) {
     s_py_callback_list_string__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_list_string__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_list_string__python_create)(void);
 
-void list_string_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void list_string_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_list_string__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__list_string.h
+++ b/test-suite/generated-src/cwrapper/dh__list_string.h
@@ -11,5 +11,5 @@ void optional_list_string___delete(struct DjinniOptionalObjectHandle *);
 void list_string_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void list_string_add_callback__get_elem(struct DjinniString *( * ptr)(struct DjinniObjectHandle *, size_t));
 void list_string_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void list_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void list_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void list_string_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, struct DjinniString *));

--- a/test-suite/generated-src/cwrapper/dh__map_boxed_int32_t_set_string.cpp
+++ b/test-suite/generated-src/cwrapper/dh__map_boxed_int32_t_set_string.cpp
@@ -50,9 +50,9 @@ void map_boxed_int32_t_set_string_add_callback__get_size(size_t( * ptr)(DjinniOb
     s_py_callback_map_boxed_int32_t_set_string__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_map_boxed_int32_t_set_string__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_map_boxed_int32_t_set_string__python_create)(void);
 
-void map_boxed_int32_t_set_string_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void map_boxed_int32_t_set_string_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_map_boxed_int32_t_set_string__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__map_boxed_int32_t_set_string.h
+++ b/test-suite/generated-src/cwrapper/dh__map_boxed_int32_t_set_string.h
@@ -11,6 +11,6 @@ void optional_map_boxed_int32_t_set_string___delete(struct DjinniOptionalObjectH
 void map_boxed_int32_t_set_string_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void map_boxed_int32_t_set_string_add_callback__get_value(struct DjinniObjectHandle *( * ptr)(struct DjinniObjectHandle *, struct DjinniBoxedI32 *));
 void map_boxed_int32_t_set_string_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void map_boxed_int32_t_set_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void map_boxed_int32_t_set_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void map_boxed_int32_t_set_string_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, struct DjinniBoxedI32 *, struct DjinniObjectHandle *));
 void map_boxed_int32_t_set_string_add_callback__python_next(struct DjinniBoxedI32 *( * ptr)(struct DjinniObjectHandle *));

--- a/test-suite/generated-src/cwrapper/dh__map_enum_color_enum_color.cpp
+++ b/test-suite/generated-src/cwrapper/dh__map_enum_color_enum_color.cpp
@@ -37,9 +37,9 @@ void map_enum_color_enum_color_add_callback__get_size(size_t( * ptr)(DjinniObjec
     s_py_callback_map_enum_color_enum_color__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_map_enum_color_enum_color__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_map_enum_color_enum_color__python_create)(void);
 
-void map_enum_color_enum_color_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void map_enum_color_enum_color_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_map_enum_color_enum_color__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__map_enum_color_enum_color.h
+++ b/test-suite/generated-src/cwrapper/dh__map_enum_color_enum_color.h
@@ -9,6 +9,6 @@ void optional_map_enum_color_enum_color___delete(struct DjinniOptionalObjectHand
 void map_enum_color_enum_color_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void map_enum_color_enum_color_add_callback__get_value(int( * ptr)(struct DjinniObjectHandle *, int));
 void map_enum_color_enum_color_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void map_enum_color_enum_color_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void map_enum_color_enum_color_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void map_enum_color_enum_color_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, int, int));
 void map_enum_color_enum_color_add_callback__python_next(int( * ptr)(struct DjinniObjectHandle *));

--- a/test-suite/generated-src/cwrapper/dh__map_enum_color_string.cpp
+++ b/test-suite/generated-src/cwrapper/dh__map_enum_color_string.cpp
@@ -43,9 +43,9 @@ void map_enum_color_string_add_callback__get_size(size_t( * ptr)(DjinniObjectHan
     s_py_callback_map_enum_color_string__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_map_enum_color_string__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_map_enum_color_string__python_create)(void);
 
-void map_enum_color_string_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void map_enum_color_string_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_map_enum_color_string__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__map_enum_color_string.h
+++ b/test-suite/generated-src/cwrapper/dh__map_enum_color_string.h
@@ -12,6 +12,6 @@ void optional_map_enum_color_string___delete(struct DjinniOptionalObjectHandle *
 void map_enum_color_string_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void map_enum_color_string_add_callback__get_value(struct DjinniString *( * ptr)(struct DjinniObjectHandle *, int));
 void map_enum_color_string_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void map_enum_color_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void map_enum_color_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void map_enum_color_string_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, int, struct DjinniString *));
 void map_enum_color_string_add_callback__python_next(int( * ptr)(struct DjinniObjectHandle *));

--- a/test-suite/generated-src/cwrapper/dh__map_int32_t_int32_t.cpp
+++ b/test-suite/generated-src/cwrapper/dh__map_int32_t_int32_t.cpp
@@ -33,9 +33,9 @@ void map_int32_t_int32_t_add_callback__get_size(size_t( * ptr)(DjinniObjectHandl
     s_py_callback_map_int32_t_int32_t__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_map_int32_t_int32_t__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_map_int32_t_int32_t__python_create)(void);
 
-void map_int32_t_int32_t_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void map_int32_t_int32_t_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_map_int32_t_int32_t__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__map_int32_t_int32_t.h
+++ b/test-suite/generated-src/cwrapper/dh__map_int32_t_int32_t.h
@@ -11,6 +11,6 @@ void optional_map_int32_t_int32_t___delete(struct DjinniOptionalObjectHandle *);
 void map_int32_t_int32_t_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void map_int32_t_int32_t_add_callback__get_value(int32_t( * ptr)(struct DjinniObjectHandle *, int32_t));
 void map_int32_t_int32_t_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void map_int32_t_int32_t_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void map_int32_t_int32_t_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void map_int32_t_int32_t_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, int32_t, int32_t));
 void map_int32_t_int32_t_add_callback__python_next(int32_t( * ptr)(struct DjinniObjectHandle *));

--- a/test-suite/generated-src/cwrapper/dh__map_int8_t_list_date.cpp
+++ b/test-suite/generated-src/cwrapper/dh__map_int8_t_list_date.cpp
@@ -50,9 +50,9 @@ void map_int8_t_list_date_add_callback__get_size(size_t( * ptr)(DjinniObjectHand
     s_py_callback_map_int8_t_list_date__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_map_int8_t_list_date__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_map_int8_t_list_date__python_create)(void);
 
-void map_int8_t_list_date_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void map_int8_t_list_date_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_map_int8_t_list_date__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__map_int8_t_list_date.h
+++ b/test-suite/generated-src/cwrapper/dh__map_int8_t_list_date.h
@@ -11,6 +11,6 @@ void optional_map_int8_t_list_date___delete(struct DjinniOptionalObjectHandle *)
 void map_int8_t_list_date_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void map_int8_t_list_date_add_callback__get_value(struct DjinniObjectHandle *( * ptr)(struct DjinniObjectHandle *, int8_t));
 void map_int8_t_list_date_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void map_int8_t_list_date_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void map_int8_t_list_date_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void map_int8_t_list_date_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, int8_t, struct DjinniObjectHandle *));
 void map_int8_t_list_date_add_callback__python_next(int8_t( * ptr)(struct DjinniObjectHandle *));

--- a/test-suite/generated-src/cwrapper/dh__map_int8_t_set_string.cpp
+++ b/test-suite/generated-src/cwrapper/dh__map_int8_t_set_string.cpp
@@ -50,9 +50,9 @@ void map_int8_t_set_string_add_callback__get_size(size_t( * ptr)(DjinniObjectHan
     s_py_callback_map_int8_t_set_string__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_map_int8_t_set_string__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_map_int8_t_set_string__python_create)(void);
 
-void map_int8_t_set_string_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void map_int8_t_set_string_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_map_int8_t_set_string__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__map_int8_t_set_string.h
+++ b/test-suite/generated-src/cwrapper/dh__map_int8_t_set_string.h
@@ -11,6 +11,6 @@ void optional_map_int8_t_set_string___delete(struct DjinniOptionalObjectHandle *
 void map_int8_t_set_string_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void map_int8_t_set_string_add_callback__get_value(struct DjinniObjectHandle *( * ptr)(struct DjinniObjectHandle *, int8_t));
 void map_int8_t_set_string_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void map_int8_t_set_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void map_int8_t_set_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void map_int8_t_set_string_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, int8_t, struct DjinniObjectHandle *));
 void map_int8_t_set_string_add_callback__python_next(int8_t( * ptr)(struct DjinniObjectHandle *));

--- a/test-suite/generated-src/cwrapper/dh__map_optional_string_optional_string.cpp
+++ b/test-suite/generated-src/cwrapper/dh__map_optional_string_optional_string.cpp
@@ -50,9 +50,9 @@ void map_optional_string_optional_string_add_callback__get_size(size_t( * ptr)(D
     s_py_callback_map_optional_string_optional_string__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_map_optional_string_optional_string__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_map_optional_string_optional_string__python_create)(void);
 
-void map_optional_string_optional_string_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void map_optional_string_optional_string_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_map_optional_string_optional_string__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__map_optional_string_optional_string.h
+++ b/test-suite/generated-src/cwrapper/dh__map_optional_string_optional_string.h
@@ -11,6 +11,6 @@ void optional_map_optional_string_optional_string___delete(struct DjinniOptional
 void map_optional_string_optional_string_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void map_optional_string_optional_string_add_callback__get_value(struct DjinniString *( * ptr)(struct DjinniObjectHandle *, struct DjinniString *));
 void map_optional_string_optional_string_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void map_optional_string_optional_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void map_optional_string_optional_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void map_optional_string_optional_string_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, struct DjinniString *, struct DjinniString *));
 void map_optional_string_optional_string_add_callback__python_next(struct DjinniString *( * ptr)(struct DjinniObjectHandle *));

--- a/test-suite/generated-src/cwrapper/dh__map_string_int32_t.cpp
+++ b/test-suite/generated-src/cwrapper/dh__map_string_int32_t.cpp
@@ -50,9 +50,9 @@ void map_string_int32_t_add_callback__get_size(size_t( * ptr)(DjinniObjectHandle
     s_py_callback_map_string_int32_t__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_map_string_int32_t__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_map_string_int32_t__python_create)(void);
 
-void map_string_int32_t_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void map_string_int32_t_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_map_string_int32_t__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__map_string_int32_t.h
+++ b/test-suite/generated-src/cwrapper/dh__map_string_int32_t.h
@@ -11,6 +11,6 @@ void optional_map_string_int32_t___delete(struct DjinniOptionalObjectHandle *);
 void map_string_int32_t_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void map_string_int32_t_add_callback__get_value(int32_t( * ptr)(struct DjinniObjectHandle *, struct DjinniString *));
 void map_string_int32_t_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void map_string_int32_t_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void map_string_int32_t_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void map_string_int32_t_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, struct DjinniString *, int32_t));
 void map_string_int32_t_add_callback__python_next(struct DjinniString *( * ptr)(struct DjinniObjectHandle *));

--- a/test-suite/generated-src/cwrapper/dh__map_string_int64_t.cpp
+++ b/test-suite/generated-src/cwrapper/dh__map_string_int64_t.cpp
@@ -43,9 +43,9 @@ void map_string_int64_t_add_callback__get_size(size_t( * ptr)(DjinniObjectHandle
     s_py_callback_map_string_int64_t__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_map_string_int64_t__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_map_string_int64_t__python_create)(void);
 
-void map_string_int64_t_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void map_string_int64_t_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_map_string_int64_t__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__map_string_int64_t.h
+++ b/test-suite/generated-src/cwrapper/dh__map_string_int64_t.h
@@ -12,6 +12,6 @@ void optional_map_string_int64_t___delete(struct DjinniOptionalObjectHandle *);
 void map_string_int64_t_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void map_string_int64_t_add_callback__get_value(int64_t( * ptr)(struct DjinniObjectHandle *, struct DjinniString *));
 void map_string_int64_t_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void map_string_int64_t_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void map_string_int64_t_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void map_string_int64_t_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, struct DjinniString *, int64_t));
 void map_string_int64_t_add_callback__python_next(struct DjinniString *( * ptr)(struct DjinniObjectHandle *));

--- a/test-suite/generated-src/cwrapper/dh__map_string_string.cpp
+++ b/test-suite/generated-src/cwrapper/dh__map_string_string.cpp
@@ -50,9 +50,9 @@ void map_string_string_add_callback__get_size(size_t( * ptr)(DjinniObjectHandle 
     s_py_callback_map_string_string__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_map_string_string__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_map_string_string__python_create)(void);
 
-void map_string_string_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void map_string_string_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_map_string_string__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__map_string_string.h
+++ b/test-suite/generated-src/cwrapper/dh__map_string_string.h
@@ -11,6 +11,6 @@ void optional_map_string_string___delete(struct DjinniOptionalObjectHandle *);
 void map_string_string_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void map_string_string_add_callback__get_value(struct DjinniString *( * ptr)(struct DjinniObjectHandle *, struct DjinniString *));
 void map_string_string_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void map_string_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void map_string_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void map_string_string_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, struct DjinniString *, struct DjinniString *));
 void map_string_string_add_callback__python_next(struct DjinniString *( * ptr)(struct DjinniObjectHandle *));

--- a/test-suite/generated-src/cwrapper/dh__set_enum_color.cpp
+++ b/test-suite/generated-src/cwrapper/dh__set_enum_color.cpp
@@ -31,9 +31,9 @@ void set_enum_color_add_callback__get_size(size_t( * ptr)(DjinniObjectHandle *))
     s_py_callback_set_enum_color__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_set_enum_color__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_set_enum_color__python_create)(void);
 
-void set_enum_color_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void set_enum_color_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_set_enum_color__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__set_enum_color.h
+++ b/test-suite/generated-src/cwrapper/dh__set_enum_color.h
@@ -8,6 +8,6 @@ void set_enum_color___delete(struct DjinniObjectHandle *);
 void optional_set_enum_color___delete(struct DjinniOptionalObjectHandle *);
 void set_enum_color_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void set_enum_color_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void set_enum_color_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void set_enum_color_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void set_enum_color_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, int));
 void set_enum_color_add_callback__python_next(int( * ptr)(struct DjinniObjectHandle *));

--- a/test-suite/generated-src/cwrapper/dh__set_int32_t.cpp
+++ b/test-suite/generated-src/cwrapper/dh__set_int32_t.cpp
@@ -27,9 +27,9 @@ void set_int32_t_add_callback__get_size(size_t( * ptr)(DjinniObjectHandle *)) {
     s_py_callback_set_int32_t__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_set_int32_t__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_set_int32_t__python_create)(void);
 
-void set_int32_t_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void set_int32_t_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_set_int32_t__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__set_int32_t.h
+++ b/test-suite/generated-src/cwrapper/dh__set_int32_t.h
@@ -10,6 +10,6 @@ void set_int32_t___delete(struct DjinniObjectHandle *);
 void optional_set_int32_t___delete(struct DjinniOptionalObjectHandle *);
 void set_int32_t_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void set_int32_t_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void set_int32_t_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void set_int32_t_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void set_int32_t_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, int32_t));
 void set_int32_t_add_callback__python_next(int32_t( * ptr)(struct DjinniObjectHandle *));

--- a/test-suite/generated-src/cwrapper/dh__set_interface_Conflict.cpp
+++ b/test-suite/generated-src/cwrapper/dh__set_interface_Conflict.cpp
@@ -26,9 +26,9 @@ void set_interface_Conflict_add_callback__get_size(size_t( * ptr)(DjinniObjectHa
     s_py_callback_set_interface_Conflict__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_set_interface_Conflict__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_set_interface_Conflict__python_create)(void);
 
-void set_interface_Conflict_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void set_interface_Conflict_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_set_interface_Conflict__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__set_interface_Conflict.h
+++ b/test-suite/generated-src/cwrapper/dh__set_interface_Conflict.h
@@ -10,6 +10,6 @@ void set_interface_Conflict___delete(struct DjinniObjectHandle *);
 void optional_set_interface_Conflict___delete(struct DjinniOptionalObjectHandle *);
 void set_interface_Conflict_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void set_interface_Conflict_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void set_interface_Conflict_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void set_interface_Conflict_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void set_interface_Conflict_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, struct DjinniWrapperConflict *));
 void set_interface_Conflict_add_callback__python_next(struct DjinniWrapperConflict *( * ptr)(struct DjinniObjectHandle *));

--- a/test-suite/generated-src/cwrapper/dh__set_optional_string.cpp
+++ b/test-suite/generated-src/cwrapper/dh__set_optional_string.cpp
@@ -44,9 +44,9 @@ void set_optional_string_add_callback__get_size(size_t( * ptr)(DjinniObjectHandl
     s_py_callback_set_optional_string__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_set_optional_string__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_set_optional_string__python_create)(void);
 
-void set_optional_string_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void set_optional_string_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_set_optional_string__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__set_optional_string.h
+++ b/test-suite/generated-src/cwrapper/dh__set_optional_string.h
@@ -10,6 +10,6 @@ void set_optional_string___delete(struct DjinniObjectHandle *);
 void optional_set_optional_string___delete(struct DjinniOptionalObjectHandle *);
 void set_optional_string_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void set_optional_string_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void set_optional_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void set_optional_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void set_optional_string_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, struct DjinniString *));
 void set_optional_string_add_callback__python_next(struct DjinniString *( * ptr)(struct DjinniObjectHandle *));

--- a/test-suite/generated-src/cwrapper/dh__set_string.cpp
+++ b/test-suite/generated-src/cwrapper/dh__set_string.cpp
@@ -44,9 +44,9 @@ void set_string_add_callback__get_size(size_t( * ptr)(DjinniObjectHandle *)) {
     s_py_callback_set_string__get_size = ptr;
 }
 
-static DjinniObjectHandle * ( * s_py_callback_set_string__python_create)();
+static DjinniObjectHandle * ( * s_py_callback_set_string__python_create)(void);
 
-void set_string_add_callback__python_create(DjinniObjectHandle *( * ptr)()) {
+void set_string_add_callback__python_create(DjinniObjectHandle *( * ptr)(void)) {
     s_py_callback_set_string__python_create = ptr;
 }
 

--- a/test-suite/generated-src/cwrapper/dh__set_string.h
+++ b/test-suite/generated-src/cwrapper/dh__set_string.h
@@ -10,6 +10,6 @@ void set_string___delete(struct DjinniObjectHandle *);
 void optional_set_string___delete(struct DjinniOptionalObjectHandle *);
 void set_string_add_callback___delete(void(* ptr)(struct DjinniObjectHandle * ));
 void set_string_add_callback__get_size(size_t( * ptr)(struct DjinniObjectHandle *));
-void set_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)());
+void set_string_add_callback__python_create(struct DjinniObjectHandle *( * ptr)(void));
 void set_string_add_callback__python_add(void( * ptr)(struct DjinniObjectHandle *, struct DjinniString *));
 void set_string_add_callback__python_next(struct DjinniString *( * ptr)(struct DjinniObjectHandle *));


### PR DESCRIPTION
Fixing two issues here, both related to building Python on a Mac.  The second issue had to be fixed to let me test the fix for the first.

1. Xcode 9 has a new warning for C in which (unlike C++) `foo()` (meaning unspecified args) vs. `foo(void)` (meaning no args).  I altered the support-lib and generator to always use `(void)`, which works fine in C++ too.

2. The dylib we use in our example app won't load because new security features have disabled DYLD_LIBRARY_PATH.  I hacked around it by using an explicit library load path.

Fixes #327 
