### PR TITLE
Fixes error: expression is not a constant expression

### DIFF
--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -80,7 +80,7 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
           w.w(s"constexpr $self operator$op($self lhs, $self rhs) noexcept").braced {
             w.wl(s"return static_cast<$self>(static_cast<$flagsType>(lhs) $op static_cast<$flagsType>(rhs));")
           }
-          w.w(s"inline $self& operator$op=($self& lhs, const $self rhs) noexcept").braced {
+          w.w(s"inline $self& operator$op=($self& lhs, $self rhs) noexcept").braced {
             w.wl(s"return lhs = lhs $op rhs;") // Ugly, yes, but complies with C++11 restricted constexpr
           }
         }

--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -80,7 +80,7 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
           w.w(s"constexpr $self operator$op($self lhs, $self rhs) noexcept").braced {
             w.wl(s"return static_cast<$self>(static_cast<$flagsType>(lhs) $op static_cast<$flagsType>(rhs));")
           }
-          w.w(s"constexpr $self& operator$op=($self& lhs, $self rhs) noexcept").braced {
+          w.w(s"inline $self& operator$op=($self& lhs, const $self rhs) noexcept").braced {
             w.wl(s"return lhs = lhs $op rhs;") // Ugly, yes, but complies with C++11 restricted constexpr
           }
         }

--- a/test-suite/generated-src/cpp/access_flags.hpp
+++ b/test-suite/generated-src/cpp/access_flags.hpp
@@ -23,19 +23,19 @@ enum class access_flags : unsigned {
 constexpr access_flags operator|(access_flags lhs, access_flags rhs) noexcept {
     return static_cast<access_flags>(static_cast<unsigned>(lhs) | static_cast<unsigned>(rhs));
 }
-constexpr access_flags& operator|=(access_flags& lhs, access_flags rhs) noexcept {
+inline access_flags& operator|=(access_flags& lhs, access_flags rhs) noexcept {
     return lhs = lhs | rhs;
 }
 constexpr access_flags operator&(access_flags lhs, access_flags rhs) noexcept {
     return static_cast<access_flags>(static_cast<unsigned>(lhs) & static_cast<unsigned>(rhs));
 }
-constexpr access_flags& operator&=(access_flags& lhs, access_flags rhs) noexcept {
+inline access_flags& operator&=(access_flags& lhs, access_flags rhs) noexcept {
     return lhs = lhs & rhs;
 }
 constexpr access_flags operator^(access_flags lhs, access_flags rhs) noexcept {
     return static_cast<access_flags>(static_cast<unsigned>(lhs) ^ static_cast<unsigned>(rhs));
 }
-constexpr access_flags& operator^=(access_flags& lhs, access_flags rhs) noexcept {
+inline access_flags& operator^=(access_flags& lhs, access_flags rhs) noexcept {
     return lhs = lhs ^ rhs;
 }
 constexpr access_flags operator~(access_flags x) noexcept {

--- a/test-suite/generated-src/cpp/empty_flags.hpp
+++ b/test-suite/generated-src/cpp/empty_flags.hpp
@@ -14,19 +14,19 @@ enum class empty_flags : unsigned {
 constexpr empty_flags operator|(empty_flags lhs, empty_flags rhs) noexcept {
     return static_cast<empty_flags>(static_cast<unsigned>(lhs) | static_cast<unsigned>(rhs));
 }
-constexpr empty_flags& operator|=(empty_flags& lhs, empty_flags rhs) noexcept {
+inline empty_flags& operator|=(empty_flags& lhs, empty_flags rhs) noexcept {
     return lhs = lhs | rhs;
 }
 constexpr empty_flags operator&(empty_flags lhs, empty_flags rhs) noexcept {
     return static_cast<empty_flags>(static_cast<unsigned>(lhs) & static_cast<unsigned>(rhs));
 }
-constexpr empty_flags& operator&=(empty_flags& lhs, empty_flags rhs) noexcept {
+inline empty_flags& operator&=(empty_flags& lhs, empty_flags rhs) noexcept {
     return lhs = lhs & rhs;
 }
 constexpr empty_flags operator^(empty_flags lhs, empty_flags rhs) noexcept {
     return static_cast<empty_flags>(static_cast<unsigned>(lhs) ^ static_cast<unsigned>(rhs));
 }
-constexpr empty_flags& operator^=(empty_flags& lhs, empty_flags rhs) noexcept {
+inline empty_flags& operator^=(empty_flags& lhs, empty_flags rhs) noexcept {
     return lhs = lhs ^ rhs;
 }
 constexpr empty_flags operator~(empty_flags x) noexcept {


### PR DESCRIPTION
In GCC 7.2, the bitwise assignment operators generated for C++ flags can not be constexpr, causing the build to fail. This patch makes them inline instead. Also, the second argument is made const to silence some diagnostics in Visual Studio.