### PR TITLE
Fix run and run-assume-built scripts when CDPATH is set

### DIFF
--- a/src/run
+++ b/src/run
@@ -12,7 +12,7 @@ while [ -h "$loc" ]; do
         loc="`dirname "$loc"`/$link"  # Relative link
     fi
 done
-base_dir=$(cd "`dirname "$loc"`" && pwd)
+base_dir=$(cd "`dirname "$loc"`" > /dev/null && pwd)
 
 "$base_dir/build"
 

--- a/src/run-assume-built
+++ b/src/run-assume-built
@@ -12,6 +12,6 @@ while [ -h "$loc" ]; do
         loc="`dirname "$loc"`/$link"  # Relative link
     fi
 done
-base_dir=$(cd "`dirname "$loc"`" && pwd)
+base_dir=$(cd "`dirname "$loc"`" > /dev/null && pwd)
 
 exec "$base_dir/target/start" "$@"


### PR DESCRIPTION
When the CDPATH environment variable is set, the cd command prints the path of the directory to stdout. Redirect that output to /dev/null to avoid it being mistakenly included in the base_dir variable, which then causes cryptic errors.