### PR TITLE
support-lib: don't let a noexcept function throw exceptions

### DIFF
--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -594,10 +594,9 @@ void jniDefaultSetPendingFromCurrent(JNIEnv * env, const char * /*ctx*/) noexcep
         return;
     } catch (const std::exception & e) {
         env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+    } catch (...) {
+        std::terminate();
     }
-
-    // noexcept will call terminate() for anything not caught above (i.e.
-    // exceptions which aren't std::exception subclasses).
 }
 
 template class ProxyCache<JavaProxyCacheTraits>;


### PR DESCRIPTION
Fixes a compilation error following NDK update:

`../deps/djinni/support-lib/jni/djinni_support.cpp:456:9: error: 'jniDefaultSetPendingFromCurrent' has a non-throwing exception specification but can still
      throw [-Werror,-Wexceptions]
        throw;
        ^
../deps/djinni/support-lib/jni/djinni_support.cpp:453:6: note: function declared non-throwing here
void jniDefaultSetPendingFromCurrent(JNIEnv * env, const char * /*ctx*/) noexcept {
     ^                                                                   ~~~~~~~~`