### PR TITLE
Provides Clang Compatibility

### DIFF
--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -601,8 +601,8 @@ void jniDefaultSetPendingFromCurrent(JNIEnv * env, const char * /*ctx*/) noexcep
 	jniDefaultSetPendingFromCurrentClangCompatibility(env);
 
     /* noexcept will call terminate() for anything not caught in 
-	   jniDefaultSetPendingFromCurrent (i.e. exceptions which aren't
-	   std::exception subclasses). */
+	   jniDefaultSetPendingFromCurrentClangCompatibility (i.e. 
+	   exceptions which aren't std::exception subclasses). */
 }
 
 template class ProxyCache<JavaProxyCacheTraits>;

--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -585,7 +585,7 @@ void jniSetPendingFromCurrent(JNIEnv * env, const char * ctx) noexcept {
     jniDefaultSetPendingFromCurrent(env, ctx);
 }
 
-void jniDefaultSetPendingFromCurrent(JNIEnv * env, const char * /*ctx*/) noexcept {
+void jniDefaultSetPendingFromCurrentClangCompatibility(JNIEnv * env) {
     assert(env);
     try {
         throw;
@@ -595,9 +595,14 @@ void jniDefaultSetPendingFromCurrent(JNIEnv * env, const char * /*ctx*/) noexcep
     } catch (const std::exception & e) {
         env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
     }
+}
 
-    // noexcept will call terminate() for anything not caught above (i.e.
-    // exceptions which aren't std::exception subclasses).
+void jniDefaultSetPendingFromCurrent(JNIEnv * env, const char * /*ctx*/) noexcept {
+	jniDefaultSetPendingFromCurrentClangCompatibility(env);
+
+    /* noexcept will call terminate() for anything not caught in 
+	   jniDefaultSetPendingFromCurrent (i.e. exceptions which aren't
+	   std::exception subclasses). */
 }
 
 template class ProxyCache<JavaProxyCacheTraits>;


### PR DESCRIPTION
Without this, clang will treat it as an error that `jniDefaultSetPendingFromCurrent` could potentially throw an uncaught exception. Compare PR #367 and issue #377. With this change, I had no issues compiling and running the Android example with clang from NDK r17b. 

Note: For anyone else trying to build with clang, I also made the following modifications locally, but did not commit them:

- remove everywhere the compiler flag -Wo-literal-suffix is used
- in `example/android/app/jni/Application.mk`:
  - `NDK_TOOLCHAIN_VERSION := clang`
  - `APP_PLATFORM := android-23`
  - `APP_STL := c++_shared`
