### PR TITLE
Check for Duplicate Output Paths

### DIFF
--- a/src/source/Main.scala
+++ b/src/source/Main.scala
@@ -244,35 +244,6 @@ object Main {
     objcIdentStyle = objcIdentStyle.copy(ty = IdentStyle.prefix(objcTypePrefix,objcIdentStyle.ty))
     objcFileIdentStyle = IdentStyle.prefix(objcTypePrefix, objcFileIdentStyle)
 
-    // Check for duplicates
-    var outputPaths = Map[String, String]()
-    for (path <- cppOutFolder) outputPaths += (
-      "cpp source" -> s"$path/${cppFileIdentStyle("FooBar")}.$cppExt",
-      "cpp header" -> s"${cppHeaderOutFolder.get}/${cppFileIdentStyle("FooBar")}.$cppHeaderExt"
-    )
-    for (path <- jniOutFolder) outputPaths += (
-      "jni source" -> s"$path/${jniFileIdentStyle("FooBar")}.$cppExt",
-      "jni header" -> s"${jniHeaderOutFolder.get}/${jniFileIdentStyle("FooBar")}.$cppHeaderExt"
-    )
-    for (path <- objcOutFolder) outputPaths += (
-      "objc source" -> s"$path/${objcFileIdentStyle("FooBar")}.m", 
-      "objc header" -> s"$path/${objcFileIdentStyle("FooBar")}.$objcHeaderExt"
-    )
-    for (path <- objcppOutFolder) outputPaths += (
-      "objcpp source" -> s"$path/${objcFileIdentStyle("FooBar")}.$objcppExt"
-    )
-
-    for ((type1, path1) <- outputPaths) {
-      for ((type2, path2) <- outputPaths) {
-        if (type1 != type2 && path1 == path2) {
-          System.err.println(
-            s"$type1 and $type2 files conflict (both output to $path1).\n" +
-            "Please adjust the options you're passing to djinni (see --help)")
-          System.exit(1); return
-        }
-      }
-    }
-
     if (cppTypeEnumIdentStyle != null) {
       cppIdentStyle = cppIdentStyle.copy(enumType = cppTypeEnumIdentStyle)
     }

--- a/src/source/Main.scala
+++ b/src/source/Main.scala
@@ -244,6 +244,35 @@ object Main {
     objcIdentStyle = objcIdentStyle.copy(ty = IdentStyle.prefix(objcTypePrefix,objcIdentStyle.ty))
     objcFileIdentStyle = IdentStyle.prefix(objcTypePrefix, objcFileIdentStyle)
 
+    // Check for duplicates
+    var outputPaths = Map[String, String]()
+    for (path <- cppOutFolder) outputPaths += (
+      "cpp source" -> s"$path/${cppFileIdentStyle("FooBar")}.$cppExt",
+      "cpp header" -> s"${cppHeaderOutFolder.get}/${cppFileIdentStyle("FooBar")}.$cppHeaderExt"
+    )
+    for (path <- jniOutFolder) outputPaths += (
+      "jni source" -> s"$path/${jniFileIdentStyle("FooBar")}.$cppExt",
+      "jni header" -> s"${jniHeaderOutFolder.get}/${jniFileIdentStyle("FooBar")}.$cppHeaderExt"
+    )
+    for (path <- objcOutFolder) outputPaths += (
+      "objc source" -> s"$path/${objcFileIdentStyle("FooBar")}.m", 
+      "objc header" -> s"$path/${objcFileIdentStyle("FooBar")}.$objcHeaderExt"
+    )
+    for (path <- objcppOutFolder) outputPaths += (
+      "objcpp source" -> s"$path/${objcFileIdentStyle("FooBar")}.$objcppExt"
+    )
+
+    for ((type1, path1) <- outputPaths) {
+      for ((type2, path2) <- outputPaths) {
+        if (type1 != type2 && path1 == path2) {
+          System.err.println(
+            s"$type1 and $type2 files conflict (both output to $path1).\n" +
+            "Please adjust the options you're passing to djinni (see --help)")
+          System.exit(1); return
+        }
+      }
+    }
+
     if (cppTypeEnumIdentStyle != null) {
       cppIdentStyle = cppIdentStyle.copy(enumType = cppTypeEnumIdentStyle)
     }

--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -240,9 +240,12 @@ package object generatorTools {
   case class DeclRef(decl: String, namespace: Option[String]) extends SymbolReference
 }
 
+object Generator {
+  val writtenFiles = mutable.HashMap[String,String]()
+}
+
 abstract class Generator(spec: Spec)
 {
-  protected val writtenFiles = mutable.HashMap[String,String]()
 
   protected def createFile(folder: File, fileName: String, makeWriter: OutputStreamWriter => IndentWriter, f: IndentWriter => Unit): Unit = {
     if (spec.outFileListWriter.isDefined) {
@@ -254,7 +257,7 @@ abstract class Generator(spec: Spec)
 
     val file = new File(folder, fileName)
     val cp = file.getCanonicalPath
-    writtenFiles.put(cp.toLowerCase, cp) match {
+    Generator.writtenFiles.put(cp.toLowerCase, cp) match {
       case Some(existing) =>
         if (existing == cp) {
           throw GenerateException("Refusing to write \"" + file.getPath + "\"; we already wrote a file to that path.")


### PR DESCRIPTION
This adds some simple logic to check whether files are set to overwrite each other. This is especially helpful for newcomers who are confused when the default settings cause this issue. Fixes #380 