### PR TITLE
Fix generation error with toString and include missing changes.

### DIFF
--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -68,6 +68,7 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
     val underlyingType = if(e.flags) flagsType else enumType
 
     writeHppFile(ident, origin, refs.hpp, refs.hppFwds, w => {
+      writeDoc(w, doc)
       w.w(s"enum class $self : $underlyingType").bracedSemi {
         writeEnumOptionNone(w, e, idCpp.enum)
         writeEnumOptions(w, e, idCpp.enum)

--- a/src/source/JavaGenerator.scala
+++ b/src/source/JavaGenerator.scala
@@ -344,6 +344,11 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
         }
 
         w.wl
+        w.wl("/**")
+        w.wl(" * Returns a string representation of this object.")
+        w.wl(" *")
+        w.wl(" * @return a string representation of this object.")
+        w.wl(" */")
         w.wl("@Override")
         w.w("public String toString()").braced {
           w.w(s"return ").nestedN(2) {
@@ -351,7 +356,10 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
             for (i <- 0 to r.fields.length-1) {
               val name = idJava.field(r.fields(i).ident)
               val comma = if (i > 0) """"," + """ else ""
-              w.wl(s"""${comma}"${name}=" + ${name} +""")
+              r.fields(i).ty.expr.ident.name match {
+                case "binary" => w.wl(s"""${comma}"${name}=" + Arrays.toString(${name}) +""")
+                case _ => w.wl(s"""${comma}"${name}=" + ${name} +""")
+              }
             }
           }
           w.wl(s""""}";""")


### PR DESCRIPTION
DESCRIPTION:
There were changes in the ix repo that weren't transfered here. These
printed off a description for toString and a description for cpp enums.
I also added a custom change when generating Java code. For the 'binary'
djinni type, the Java type is 'byte[]'. The toString method tries to
print this off by reference, which throws a Java compilation error.
Instead, in this case print with 'Arrays.toString', passing in the
'byte[]' variable.

TESTING:
Compiled and transfered the .jar file to ix repo. Ran djinni in the ix
repo, and the problems are fixed. That is, the enum descriptions are
being printed, and byte[] printing is implemented correctly.

RELEASE_NOTE:
Fixed java code generation error and include missing changes.

TICKET: