### PR TITLE
Use ‘constexpr’ in generated `.cpp` files

### DIFF
--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -175,7 +175,7 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
     for (c <- consts) {
       skipFirst{ w.wl }
       if (shouldConstexpr(c)){
-        w.w(s"${marshal.fieldType(c.ty)} const $selfName::${idCpp.const(c.ident)}")
+        w.w(s"${marshal.fieldType(c.ty)} constexpr $selfName::${idCpp.const(c.ident)}")
       } else {
         w.w(s"${marshal.fieldType(c.ty)} const $selfName::${idCpp.const(c.ident)} = ")
         writeCppConst(w, c.ty, c.value)

--- a/test-suite/generated-src/cpp/constants.cpp
+++ b/test-suite/generated-src/cpp/constants.cpp
@@ -5,19 +5,19 @@
 
 namespace testsuite {
 
-bool const Constants::BOOL_CONSTANT;
+bool constexpr Constants::BOOL_CONSTANT;
 
-int8_t const Constants::I8_CONSTANT;
+int8_t constexpr Constants::I8_CONSTANT;
 
-int16_t const Constants::I16_CONSTANT;
+int16_t constexpr Constants::I16_CONSTANT;
 
-int32_t const Constants::I32_CONSTANT;
+int32_t constexpr Constants::I32_CONSTANT;
 
-int64_t const Constants::I64_CONSTANT;
+int64_t constexpr Constants::I64_CONSTANT;
 
-float const Constants::F32_CONSTANT;
+float constexpr Constants::F32_CONSTANT;
 
-double const Constants::F64_CONSTANT;
+double constexpr Constants::F64_CONSTANT;
 
 std::experimental::optional<bool> const Constants::OPT_BOOL_CONSTANT = true;
 
@@ -41,6 +41,6 @@ ConstantRecord const Constants::OBJECT_CONSTANT = ConstantRecord(
     Constants::I32_CONSTANT /* some_integer */ ,
     Constants::STRING_CONSTANT /* some_string */ );
 
-bool const Constants::DUMMY;
+bool constexpr Constants::DUMMY;
 
 }  // namespace testsuite

--- a/test-suite/generated-src/cpp/constants_interface.cpp
+++ b/test-suite/generated-src/cpp/constants_interface.cpp
@@ -6,19 +6,19 @@
 
 namespace testsuite {
 
-bool const ConstantsInterface::BOOL_CONSTANT;
+bool constexpr ConstantsInterface::BOOL_CONSTANT;
 
-int8_t const ConstantsInterface::I8_CONSTANT;
+int8_t constexpr ConstantsInterface::I8_CONSTANT;
 
-int16_t const ConstantsInterface::I16_CONSTANT;
+int16_t constexpr ConstantsInterface::I16_CONSTANT;
 
-int32_t const ConstantsInterface::I32_CONSTANT;
+int32_t constexpr ConstantsInterface::I32_CONSTANT;
 
-int64_t const ConstantsInterface::I64_CONSTANT;
+int64_t constexpr ConstantsInterface::I64_CONSTANT;
 
-float const ConstantsInterface::F32_CONSTANT;
+float constexpr ConstantsInterface::F32_CONSTANT;
 
-double const ConstantsInterface::F64_CONSTANT;
+double constexpr ConstantsInterface::F64_CONSTANT;
 
 std::experimental::optional<bool> const ConstantsInterface::OPT_BOOL_CONSTANT = true;
 


### PR DESCRIPTION
Fix compile error: ‘constexpr’ needed for in-class initialization of static data member.