### PR TITLE
Make #379 compatible with python branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Djinni's input is an interface description file. Here's an example:
         store: set<string>;
         hash: map<string, i32>;
 
+        // You can generate two types of comments
+        // - Code comments by using "// comment" in djinni files which will generate "// comment" 
+        // - Code documentation by using "# comment" in djinni files which will generate "/** comment */" 
+        // Both of those types support single and multi line comments 
         values: list<another_record>;
 
         # Comments can also be put here
@@ -505,6 +509,14 @@ There is basically two variables you would like to modify:
 For more informations, take a look at https://github.com/leetal/ios-cmake.
 
 - `ENABLE_BITCODE`: enable/disable the bitcode generation.
+
+## Android Parcelable records
+
+Djinni supports generating records that implements `android.os.parcelable`.
+
+In order to do that, there are two steps needed:
+- deriving the records that should be parcelable with the keyword parcelable: `deriving(parcelable)`
+- run Djinni with the following flag `--java-implement-android-os-parcelable true`
 
 ## Community Links
 

--- a/example/example.djinni
+++ b/example/example.djinni
@@ -9,7 +9,7 @@ sort_order = enum {
 }
 
 sort_items = interface +c {
-    # For the iOS / Android demo
+    // For the iOS / Android demo
     sort(order: sort_order, items: item_list);
     static create_with_listener(listener: textbox_listener): sort_items;
 

--- a/example/generated-src/cpp/sort_items.hpp
+++ b/example/generated-src/cpp/sort_items.hpp
@@ -15,7 +15,7 @@ class SortItems {
 public:
     virtual ~SortItems() {}
 
-    /** For the iOS / Android demo */
+    // For the iOS / Android demo
     virtual void sort(sort_order order, const ItemList & items) = 0;
 
     static std::shared_ptr<SortItems> create_with_listener(const std::shared_ptr<TextboxListener> & listener);

--- a/example/generated-src/java/com/dropbox/textsort/SortItems.java
+++ b/example/generated-src/java/com/dropbox/textsort/SortItems.java
@@ -8,7 +8,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 /*package*/ interface SortItems {
-    /** For the iOS / Android demo */
+    // For the iOS / Android demo
     public void sort(@Nonnull SortOrder order, @Nonnull ItemList items);
 
     @CheckForNull

--- a/example/generated-src/objc/TXSSortItems.h
+++ b/example/generated-src/objc/TXSSortItems.h
@@ -10,7 +10,7 @@
 
 @interface TXSSortItems : NSObject
 
-/** For the iOS / Android demo */
+// For the iOS / Android demo
 - (void)sort:(TXSSortOrder)order
        items:(nonnull TXSItemList *)items;
 

--- a/src/run
+++ b/src/run
@@ -12,7 +12,7 @@ while [ -h "$loc" ]; do
         loc="`dirname "$loc"`/$link"  # Relative link
     fi
 done
-base_dir=$(cd "`dirname "$loc"`" && pwd)
+base_dir=$(cd "`dirname "$loc"`" > /dev/null && pwd)
 
 "$base_dir/build"
 

--- a/src/run-assume-built
+++ b/src/run-assume-built
@@ -12,6 +12,6 @@ while [ -h "$loc" ]; do
         loc="`dirname "$loc"`/$link"  # Relative link
     fi
 done
-base_dir=$(cd "`dirname "$loc"`" && pwd)
+base_dir=$(cd "`dirname "$loc"`" > /dev/null && pwd)
 
 exec "$base_dir/target/start" "$@"

--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -175,7 +175,7 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
     for (c <- consts) {
       skipFirst{ w.wl }
       if (shouldConstexpr(c)){
-        w.w(s"${marshal.fieldType(c.ty)} const $selfName::${idCpp.const(c.ident)}")
+        w.w(s"${marshal.fieldType(c.ty)} constexpr $selfName::${idCpp.const(c.ident)}")
       } else {
         w.w(s"${marshal.fieldType(c.ty)} const $selfName::${idCpp.const(c.ident)} = ")
         writeCppConst(w, c.ty, c.value)

--- a/src/source/ast.scala
+++ b/src/source/ast.scala
@@ -35,7 +35,13 @@ class EnumValue(val ty: Ident, ident: Ident) extends Ident(ident.name, ident.fil
 
 case class TypeParam(ident: Ident)
 
-case class Doc(lines: Seq[String])
+case class Doc(comments: Seq[Comment])
+
+abstract sealed class Comment {
+  val lines: Seq[String]
+}
+case class CodeComment(override val lines: Seq[String]) extends Comment
+case class DocComment(override val lines: Seq[String]) extends Comment
 
 sealed abstract class TypeDecl {
   val ident: Ident

--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -18,12 +18,15 @@ package djinni
 
 import djinni.ast._
 import java.io._
+
 import djinni.generatorTools._
 import djinni.meta._
 import djinni.syntax.Error
 import djinni.writer.IndentWriter
+
 import scala.language.implicitConversions
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 import scala.util.matching.Regex
 
 package object generatorTools {
@@ -504,22 +507,44 @@ abstract class Generator(spec: Spec)
 
   def writeMethodDoc(w: IndentWriter, method: Interface.Method, ident: IdentConverter) {
     val paramReplacements = method.params.map(p => (s"\\b${Regex.quote(p.ident.name)}\\b", s"${ident(p.ident.name)}"))
-    val newDoc = Doc(method.doc.lines.map(l => {
-      paramReplacements.foldLeft(l)((line, rep) =>
-        line.replaceAll(rep._1, rep._2))
-    }))
+
+    val comments = ArrayBuffer[Comment]()
+
+    method.doc.comments.foreach({
+      case DocComment(lines) =>
+
+        val newDocComment = DocComment(lines.map(l => {
+          paramReplacements.foldLeft(l)((line, rep) =>
+            line.replaceAll(rep._1, rep._2))
+        }))
+
+        comments += newDocComment
+
+      case CodeComment(lines) =>
+        comments += CodeComment(lines)
+    })
+
+    val newDoc = Doc(comments)
+
     writeDoc(w, newDoc)
   }
 
   def writeDoc(w: IndentWriter, doc: Doc) {
-    doc.lines.length match {
-      case 0 =>
-      case 1 =>
-        w.wl(s"/**${doc.lines.head} */")
-      case _ =>
-        w.wl("/**")
-        doc.lines.foreach (l => w.wl(s" *$l"))
-        w.wl(" */")
-    }
+    doc.comments.foreach({
+      case DocComment(lines) =>
+        lines.length match {
+          case 0 =>
+          case 1 =>
+            w.wl(s"/**${lines.head} */")
+          case _ =>
+            w.wl("/**")
+            lines.foreach (l => w.wl(s" *$l"))
+            w.wl(" */")
+        }
+
+      case CodeComment(lines) =>
+        lines.foreach (l => w.wl(s"//$l"))
+    })
   }
+
 }

--- a/test-suite/djinni/client_interface.djinni
+++ b/test-suite/djinni/client_interface.djinni
@@ -1,17 +1,20 @@
-# Record returned by a client
+// Record returned by a client
 client_returned_record = record {
     record_id: i64;
     content: string;
     misc: optional<string>;
 }
 
-# Client interface
+// Client interface
 client_interface = interface +p +j +o {
+    // Testing code comments before documentation comments
     # Returns record of given string
     get_record(record_id: i64, utf8string: string, misc: optional<string>): client_returned_record;
 	identifier_check(data: binary, r: i32, jret: i64): f64;
     return_str(): string;
 
+    # Testing documentation comments before code comments
+    // This method takes an interface
     meth_taking_interface(i: client_interface): string;
     meth_taking_optional_interface(i: optional<client_interface>): string;
 }
@@ -19,7 +22,20 @@ client_interface = interface +p +j +o {
 reverse_client_interface = interface +c {
     const return_str(): string;
 
+    // Testing code comments before documentation comments
+    // with multiple lines
+    // and another line
+    # Testing documentation comments after code comments
+    # with multiple lines
+    # and another line
     meth_taking_interface(i: reverse_client_interface): string;
+
+    # Testing documentation comments before code comments
+    # with multiple lines
+    # and another line
+    // Testing code comments after documentation comments
+    // with multiple lines
+    // and another line
     meth_taking_optional_interface(i: optional<reverse_client_interface>): string;
 
     static create(): reverse_client_interface;

--- a/test-suite/djinni/constant_enum.djinni
+++ b/test-suite/djinni/constant_enum.djinni
@@ -1,4 +1,4 @@
-# enum for use in constants
+// enum for use in constants
 constant_enum = enum {
     some_value;
     some_other_value;

--- a/test-suite/djinni/constants.djinni
+++ b/test-suite/djinni/constants.djinni
@@ -8,10 +8,14 @@ constant_record = record {
 constants = record {
     # bool_constant has documentation.
     const bool_constant: bool = true;
+    // i8_constant has a comment
     const i8_constant: i8 = 1;
     const i16_constant: i16 = 2;
     const i32_constant: i32 = 3;
     const i64_constant: i64 = 4;
+    // f64_constant has a long comment.
+    // (Second line of multi-line comment.
+    //   Indented third line of multi-line comment.)
     const f32_constant: f32 = 5.0;
     # f64_constant has long documentation.
     # (Second line of multi-line documentation.
@@ -39,7 +43,7 @@ constants = record {
     };
 
     # No support for null optional constants
-    # No support for optional constant records
+    // No support for optional constant records
     # No support for constant binary, list, set, map
 
     const dummy: bool = false;
@@ -79,9 +83,9 @@ constants_interface = interface +c {
         some_string = string_constant
     };
 
-    # No support for null optional constants
+    // No support for null optional constants
     # No support for optional constant records
-    # No support for constant binary, list, set, map
+    // No support for constant binary, list, set, map
 
     dummy();
 }

--- a/test-suite/djinni/enum.djinni
+++ b/test-suite/djinni/enum.djinni
@@ -2,6 +2,9 @@ color = enum {
 	red;
 	orange;
 	yellow;
+	// "It is customary to list indigo as a color lying between blue and violet, but it has
+	// never seemed to me that indigo is worth the dignity of being considered a separate
+	// color. To my eyes it seems merely deep blue." --Isaac Asimov
 	green;
 	blue;
 	# "It is customary to list indigo as a color lying between blue and violet, but it has

--- a/test-suite/djinni/multiple_inheritance.djinni
+++ b/test-suite/djinni/multiple_inheritance.djinni
@@ -3,7 +3,7 @@ first_listener = interface +o +p {
     first();
 }
 
-# Used for non-C++ multiple inheritance tests
+// Used for non-C++ multiple inheritance tests
 second_listener = interface +o +p {
     second();
 }
@@ -24,7 +24,7 @@ return_one = interface +c {
     return_one(): i8;
 }
 
-# Used for C++ multiple inheritance tests
+// Used for C++ multiple inheritance tests
 return_two = interface +c {
     static get_instance(): return_two;
     return_two(): i8;

--- a/test-suite/djinni/yaml-test.djinni
+++ b/test-suite/djinni/yaml-test.djinni
@@ -8,6 +8,8 @@ extern_record_with_derivings = record
 	e: test_color;
 } deriving(eq, ord)
 
+// This file tests YAML dumped by Djinni can be parsed back in
+
 extern_interface_1 = interface +c
 {
 	foo(i: test_client_interface): test_client_returned_record;

--- a/test-suite/generated-src/cpp/client_interface.hpp
+++ b/test-suite/generated-src/cpp/client_interface.hpp
@@ -13,11 +13,12 @@ namespace testsuite {
 
 struct ClientReturnedRecord;
 
-/** Client interface */
+// Client interface
 class ClientInterface {
 public:
     virtual ~ClientInterface() {}
 
+    // Testing code comments before documentation comments
     /** Returns record of given string */
     virtual ClientReturnedRecord get_record(int64_t record_id, const std::string & utf8string, const std::experimental::optional<std::string> & misc) = 0;
 
@@ -25,6 +26,8 @@ public:
 
     virtual std::string return_str() = 0;
 
+    /** Testing documentation comments before code comments */
+    // This method takes an interface
     virtual std::string meth_taking_interface(const std::shared_ptr<ClientInterface> & i) = 0;
 
     virtual std::string meth_taking_optional_interface(const std::shared_ptr<ClientInterface> & i) = 0;

--- a/test-suite/generated-src/cpp/client_returned_record.hpp
+++ b/test-suite/generated-src/cpp/client_returned_record.hpp
@@ -10,7 +10,7 @@
 
 namespace testsuite {
 
-/** Record returned by a client */
+// Record returned by a client
 struct ClientReturnedRecord final {
     int64_t record_id;
     std::string content;

--- a/test-suite/generated-src/cpp/color.hpp
+++ b/test-suite/generated-src/cpp/color.hpp
@@ -11,6 +11,9 @@ enum class color : int {
     RED,
     ORANGE,
     YELLOW,
+    // "It is customary to list indigo as a color lying between blue and violet, but it has
+    // never seemed to me that indigo is worth the dignity of being considered a separate
+    // color. To my eyes it seems merely deep blue." --Isaac Asimov
     GREEN,
     BLUE,
     /**

--- a/test-suite/generated-src/cpp/constants.cpp
+++ b/test-suite/generated-src/cpp/constants.cpp
@@ -5,19 +5,19 @@
 
 namespace testsuite {
 
-bool const Constants::BOOL_CONSTANT;
+bool constexpr Constants::BOOL_CONSTANT;
 
-int8_t const Constants::I8_CONSTANT;
+int8_t constexpr Constants::I8_CONSTANT;
 
-int16_t const Constants::I16_CONSTANT;
+int16_t constexpr Constants::I16_CONSTANT;
 
-int32_t const Constants::I32_CONSTANT;
+int32_t constexpr Constants::I32_CONSTANT;
 
-int64_t const Constants::I64_CONSTANT;
+int64_t constexpr Constants::I64_CONSTANT;
 
-float const Constants::F32_CONSTANT;
+float constexpr Constants::F32_CONSTANT;
 
-double const Constants::F64_CONSTANT;
+double constexpr Constants::F64_CONSTANT;
 
 std::experimental::optional<bool> const Constants::OPT_BOOL_CONSTANT = true;
 
@@ -41,6 +41,6 @@ ConstantRecord const Constants::OBJECT_CONSTANT = ConstantRecord(
     Constants::I32_CONSTANT /* some_integer */ ,
     Constants::STRING_CONSTANT /* some_string */ );
 
-bool const Constants::DUMMY;
+bool constexpr Constants::DUMMY;
 
 }  // namespace testsuite

--- a/test-suite/generated-src/cpp/constants.hpp
+++ b/test-suite/generated-src/cpp/constants.hpp
@@ -17,6 +17,7 @@ struct Constants final {
     /** bool_constant has documentation. */
     static constexpr bool BOOL_CONSTANT = true;
 
+    // i8_constant has a comment
     static constexpr int8_t I8_CONSTANT = 1;
 
     static constexpr int16_t I16_CONSTANT = 2;
@@ -25,6 +26,9 @@ struct Constants final {
 
     static constexpr int64_t I64_CONSTANT = 4;
 
+    // f64_constant has a long comment.
+    // (Second line of multi-line comment.
+    //   Indented third line of multi-line comment.)
     static constexpr float F32_CONSTANT = 5.0f;
 
     /**
@@ -60,11 +64,9 @@ struct Constants final {
 
     static ConstantRecord const OBJECT_CONSTANT;
 
-    /**
-     * No support for null optional constants
-     * No support for optional constant records
-     * No support for constant binary, list, set, map
-     */
+    /** No support for null optional constants */
+    // No support for optional constant records
+    /** No support for constant binary, list, set, map */
     static constexpr bool DUMMY = false;
 };
 

--- a/test-suite/generated-src/cpp/constants_interface.cpp
+++ b/test-suite/generated-src/cpp/constants_interface.cpp
@@ -6,19 +6,19 @@
 
 namespace testsuite {
 
-bool const ConstantsInterface::BOOL_CONSTANT;
+bool constexpr ConstantsInterface::BOOL_CONSTANT;
 
-int8_t const ConstantsInterface::I8_CONSTANT;
+int8_t constexpr ConstantsInterface::I8_CONSTANT;
 
-int16_t const ConstantsInterface::I16_CONSTANT;
+int16_t constexpr ConstantsInterface::I16_CONSTANT;
 
-int32_t const ConstantsInterface::I32_CONSTANT;
+int32_t constexpr ConstantsInterface::I32_CONSTANT;
 
-int64_t const ConstantsInterface::I64_CONSTANT;
+int64_t constexpr ConstantsInterface::I64_CONSTANT;
 
-float const ConstantsInterface::F32_CONSTANT;
+float constexpr ConstantsInterface::F32_CONSTANT;
 
-double const ConstantsInterface::F64_CONSTANT;
+double constexpr ConstantsInterface::F64_CONSTANT;
 
 std::experimental::optional<bool> const ConstantsInterface::OPT_BOOL_CONSTANT = true;
 

--- a/test-suite/generated-src/cpp/constants_interface.hpp
+++ b/test-suite/generated-src/cpp/constants_interface.hpp
@@ -62,11 +62,9 @@ public:
 
     static ConstantRecord const OBJECT_CONSTANT;
 
-    /**
-     * No support for null optional constants
-     * No support for optional constant records
-     * No support for constant binary, list, set, map
-     */
+    // No support for null optional constants
+    /** No support for optional constant records */
+    // No support for constant binary, list, set, map
     virtual void dummy() = 0;
 };
 

--- a/test-suite/generated-src/cpp/extern_interface_1.hpp
+++ b/test-suite/generated-src/cpp/extern_interface_1.hpp
@@ -7,6 +7,7 @@
 #include "client_returned_record.hpp"
 #include <memory>
 
+// This file tests YAML dumped by Djinni can be parsed back in
 class ExternInterface1 {
 public:
     virtual ~ExternInterface1() {}

--- a/test-suite/generated-src/cpp/return_two.hpp
+++ b/test-suite/generated-src/cpp/return_two.hpp
@@ -8,7 +8,7 @@
 
 namespace testsuite {
 
-/** Used for C++ multiple inheritance tests */
+// Used for C++ multiple inheritance tests
 class ReturnTwo {
 public:
     virtual ~ReturnTwo() {}

--- a/test-suite/generated-src/cpp/reverse_client_interface.hpp
+++ b/test-suite/generated-src/cpp/reverse_client_interface.hpp
@@ -15,8 +15,24 @@ public:
 
     virtual std::string return_str() const = 0;
 
+    // Testing code comments before documentation comments
+    // with multiple lines
+    // and another line
+    /**
+     * Testing documentation comments after code comments
+     * with multiple lines
+     * and another line
+     */
     virtual std::string meth_taking_interface(const std::shared_ptr<ReverseClientInterface> & i) = 0;
 
+    /**
+     * Testing documentation comments before code comments
+     * with multiple lines
+     * and another line
+     */
+    // Testing code comments after documentation comments
+    // with multiple lines
+    // and another line
     virtual std::string meth_taking_optional_interface(const std::shared_ptr<ReverseClientInterface> & i) = 0;
 
     static std::shared_ptr<ReverseClientInterface> create();

--- a/test-suite/generated-src/cpp/second_listener.hpp
+++ b/test-suite/generated-src/cpp/second_listener.hpp
@@ -5,7 +5,7 @@
 
 namespace testsuite {
 
-/** Used for non-C++ multiple inheritance tests */
+// Used for non-C++ multiple inheritance tests
 class SecondListener {
 public:
     virtual ~SecondListener() {}

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ClientInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ClientInterface.java
@@ -6,8 +6,9 @@ package com.dropbox.djinni.test;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
-/** Client interface */
+// Client interface
 public interface ClientInterface {
+    // Testing code comments before documentation comments
     /** Returns record of given string */
     @Nonnull
     public ClientReturnedRecord getRecord(long recordId, @Nonnull String utf8string, @CheckForNull String misc);
@@ -17,6 +18,8 @@ public interface ClientInterface {
     @Nonnull
     public String returnStr();
 
+    /** Testing documentation comments before code comments */
+    // This method takes an interface
     @Nonnull
     public String methTakingInterface(@CheckForNull ClientInterface i);
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ClientReturnedRecord.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ClientReturnedRecord.java
@@ -6,7 +6,7 @@ package com.dropbox.djinni.test;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
-/** Record returned by a client */
+// Record returned by a client
 public class ClientReturnedRecord {
 
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/Color.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/Color.java
@@ -10,6 +10,9 @@ public enum Color {
     RED,
     ORANGE,
     YELLOW,
+    // "It is customary to list indigo as a color lying between blue and violet, but it has
+    // never seemed to me that indigo is worth the dignity of being considered a separate
+    // color. To my eyes it seems merely deep blue." --Isaac Asimov
     GREEN,
     BLUE,
     /**

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantEnum.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantEnum.java
@@ -6,7 +6,7 @@ package com.dropbox.djinni.test;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
-/** enum for use in constants */
+// enum for use in constants
 public enum ConstantEnum {
     SOME_VALUE,
     SOME_OTHER_VALUE,

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/Constants.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/Constants.java
@@ -12,6 +12,7 @@ public class Constants {
     /** bool_constant has documentation. */
     public static final boolean BOOL_CONSTANT = true;
 
+    // i8_constant has a comment
     public static final byte I8_CONSTANT = 1;
 
     public static final short I16_CONSTANT = 2;
@@ -20,6 +21,9 @@ public class Constants {
 
     public static final long I64_CONSTANT = 4l;
 
+    // f64_constant has a long comment.
+    // (Second line of multi-line comment.
+    //   Indented third line of multi-line comment.)
     public static final float F32_CONSTANT = 5.0f;
 
     /**
@@ -67,11 +71,9 @@ public class Constants {
         I32_CONSTANT /* mSomeInteger */ ,
         STRING_CONSTANT /* mSomeString */ );
 
-    /**
-     * No support for null optional constants
-     * No support for optional constant records
-     * No support for constant binary, list, set, map
-     */
+    /** No support for null optional constants */
+    // No support for optional constant records
+    /** No support for constant binary, list, set, map */
     public static final boolean DUMMY = false;
 
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantsInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantsInterface.java
@@ -67,11 +67,9 @@ public interface ConstantsInterface {
         I32_CONSTANT /* mSomeInteger */ ,
         STRING_CONSTANT /* mSomeString */ );
 
-    /**
-     * No support for null optional constants
-     * No support for optional constant records
-     * No support for constant binary, list, set, map
-     */
+    // No support for null optional constants
+    /** No support for optional constant records */
+    // No support for constant binary, list, set, map
     public void dummy();
 
     static final class CppProxy implements ConstantsInterface

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ExternInterface1.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ExternInterface1.java
@@ -5,6 +5,7 @@ package com.dropbox.djinni.test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+// This file tests YAML dumped by Djinni can be parsed back in
 public interface ExternInterface1 {
     public com.dropbox.djinni.test.ClientReturnedRecord foo(com.dropbox.djinni.test.ClientInterface i);
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ReturnTwo.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ReturnTwo.java
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
-/** Used for C++ multiple inheritance tests */
+// Used for C++ multiple inheritance tests
 public interface ReturnTwo {
     public byte returnTwo();
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ReverseClientInterface.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ReverseClientInterface.java
@@ -11,9 +11,25 @@ public interface ReverseClientInterface {
     @Nonnull
     public String returnStr();
 
+    // Testing code comments before documentation comments
+    // with multiple lines
+    // and another line
+    /**
+     * Testing documentation comments after code comments
+     * with multiple lines
+     * and another line
+     */
     @Nonnull
     public String methTakingInterface(@CheckForNull ReverseClientInterface i);
 
+    /**
+     * Testing documentation comments before code comments
+     * with multiple lines
+     * and another line
+     */
+    // Testing code comments after documentation comments
+    // with multiple lines
+    // and another line
     @Nonnull
     public String methTakingOptionalInterface(@CheckForNull ReverseClientInterface i);
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/SecondListener.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/SecondListener.java
@@ -6,7 +6,7 @@ package com.dropbox.djinni.test;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
-/** Used for non-C++ multiple inheritance tests */
+// Used for non-C++ multiple inheritance tests
 public interface SecondListener {
     public void second();
 }

--- a/test-suite/generated-src/objc/DBClientInterface.h
+++ b/test-suite/generated-src/objc/DBClientInterface.h
@@ -6,9 +6,10 @@
 @protocol DBClientInterface;
 
 
-/** Client interface */
+// Client interface
 @protocol DBClientInterface
 
+// Testing code comments before documentation comments
 /** Returns record of given string */
 - (nonnull DBClientReturnedRecord *)getRecord:(int64_t)recordId
                                    utf8string:(nonnull NSString *)utf8string
@@ -20,6 +21,8 @@
 
 - (nonnull NSString *)returnStr;
 
+/** Testing documentation comments before code comments */
+// This method takes an interface
 - (nonnull NSString *)methTakingInterface:(nullable id<DBClientInterface>)i;
 
 - (nonnull NSString *)methTakingOptionalInterface:(nullable id<DBClientInterface>)i;

--- a/test-suite/generated-src/objc/DBClientReturnedRecord.h
+++ b/test-suite/generated-src/objc/DBClientReturnedRecord.h
@@ -3,7 +3,7 @@
 
 #import <Foundation/Foundation.h>
 
-/** Record returned by a client */
+// Record returned by a client
 @interface DBClientReturnedRecord : NSObject
 - (nonnull instancetype)initWithRecordId:(int64_t)recordId
                                  content:(nonnull NSString *)content

--- a/test-suite/generated-src/objc/DBColor.h
+++ b/test-suite/generated-src/objc/DBColor.h
@@ -8,6 +8,9 @@ typedef NS_ENUM(NSInteger, DBColor)
     DBColorRed,
     DBColorOrange,
     DBColorYellow,
+    // "It is customary to list indigo as a color lying between blue and violet, but it has
+    // never seemed to me that indigo is worth the dignity of being considered a separate
+    // color. To my eyes it seems merely deep blue." --Isaac Asimov
     DBColorGreen,
     DBColorBlue,
     /**

--- a/test-suite/generated-src/objc/DBConstantEnum.h
+++ b/test-suite/generated-src/objc/DBConstantEnum.h
@@ -3,7 +3,7 @@
 
 #import <Foundation/Foundation.h>
 
-/** enum for use in constants */
+// enum for use in constants
 typedef NS_ENUM(NSInteger, DBConstantEnum)
 {
     DBConstantEnumSomeValue,

--- a/test-suite/generated-src/objc/DBConstants.h
+++ b/test-suite/generated-src/objc/DBConstants.h
@@ -27,10 +27,14 @@
 
 /** bool_constant has documentation. */
 extern BOOL const DBConstantsBoolConstant;
+// i8_constant has a comment
 extern int8_t const DBConstantsI8Constant;
 extern int16_t const DBConstantsI16Constant;
 extern int32_t const DBConstantsI32Constant;
 extern int64_t const DBConstantsI64Constant;
+// f64_constant has a long comment.
+// (Second line of multi-line comment.
+//   Indented third line of multi-line comment.)
 extern float const DBConstantsF32Constant;
 /**
  * f64_constant has long documentation.
@@ -40,9 +44,7 @@ extern float const DBConstantsF32Constant;
 extern double const DBConstantsF64Constant;
 extern NSString * __nonnull const DBConstantsStringConstant;
 extern NSString * __nullable const DBConstantsOptStringConstant;
-/**
- * No support for null optional constants
- * No support for optional constant records
- * No support for constant binary, list, set, map
- */
+/** No support for null optional constants */
+// No support for optional constant records
+/** No support for constant binary, list, set, map */
 extern BOOL const DBConstantsDummy;

--- a/test-suite/generated-src/objc/DBConstantsInterface.h
+++ b/test-suite/generated-src/objc/DBConstantsInterface.h
@@ -23,11 +23,9 @@ extern NSString * __nullable const DBConstantsInterfaceOptStringConstant;
 /** Interface containing constants */
 @interface DBConstantsInterface : NSObject
 
-/**
- * No support for null optional constants
- * No support for optional constant records
- * No support for constant binary, list, set, map
- */
+// No support for null optional constants
+/** No support for optional constant records */
+// No support for constant binary, list, set, map
 - (void)dummy;
 
 + (NSNumber * __nullable)optBoolConstant;

--- a/test-suite/generated-src/objc/DBExternInterface1.h
+++ b/test-suite/generated-src/objc/DBExternInterface1.h
@@ -6,6 +6,7 @@
 #import <Foundation/Foundation.h>
 
 
+// This file tests YAML dumped by Djinni can be parsed back in
 @interface DBExternInterface1 : NSObject
 
 - (nonnull DBClientReturnedRecord *)foo:(nullable id<DBClientInterface>)i;

--- a/test-suite/generated-src/objc/DBReturnTwo.h
+++ b/test-suite/generated-src/objc/DBReturnTwo.h
@@ -5,7 +5,7 @@
 @class DBReturnTwo;
 
 
-/** Used for C++ multiple inheritance tests */
+// Used for C++ multiple inheritance tests
 @interface DBReturnTwo : NSObject
 
 + (nullable DBReturnTwo *)getInstance;

--- a/test-suite/generated-src/objc/DBReverseClientInterface.h
+++ b/test-suite/generated-src/objc/DBReverseClientInterface.h
@@ -9,8 +9,24 @@
 
 - (nonnull NSString *)returnStr;
 
+// Testing code comments before documentation comments
+// with multiple lines
+// and another line
+/**
+ * Testing documentation comments after code comments
+ * with multiple lines
+ * and another line
+ */
 - (nonnull NSString *)methTakingInterface:(nullable DBReverseClientInterface *)i;
 
+/**
+ * Testing documentation comments before code comments
+ * with multiple lines
+ * and another line
+ */
+// Testing code comments after documentation comments
+// with multiple lines
+// and another line
 - (nonnull NSString *)methTakingOptionalInterface:(nullable DBReverseClientInterface *)i;
 
 + (nullable DBReverseClientInterface *)create;

--- a/test-suite/generated-src/objc/DBSecondListener.h
+++ b/test-suite/generated-src/objc/DBSecondListener.h
@@ -4,7 +4,7 @@
 #import <Foundation/Foundation.h>
 
 
-/** Used for non-C++ multiple inheritance tests */
+// Used for non-C++ multiple inheritance tests
 @protocol DBSecondListener
 
 - (void)second;

--- a/test-suite/generated-src/pycpp/client_interface.hpp
+++ b/test-suite/generated-src/pycpp/client_interface.hpp
@@ -13,11 +13,12 @@ namespace testsuite {
 
 struct ClientReturnedRecord;
 
-/** Client interface */
+// Client interface
 class ClientInterface {
 public:
     virtual ~ClientInterface() {}
 
+    // Testing code comments before documentation comments
     /** Returns record of given string */
     virtual ClientReturnedRecord get_record(int64_t record_id, const std::string & utf8string, const std::experimental::optional<std::string> & misc) = 0;
 
@@ -25,6 +26,8 @@ public:
 
     virtual std::string return_str() = 0;
 
+    /** Testing documentation comments before code comments */
+    // This method takes an interface
     virtual std::string meth_taking_interface(const std::shared_ptr<ClientInterface> & i) = 0;
 
     virtual std::string meth_taking_optional_interface(const std::shared_ptr<ClientInterface> & i) = 0;

--- a/test-suite/generated-src/pycpp/client_returned_record.hpp
+++ b/test-suite/generated-src/pycpp/client_returned_record.hpp
@@ -10,7 +10,7 @@
 
 namespace testsuite {
 
-/** Record returned by a client */
+// Record returned by a client
 struct ClientReturnedRecord final {
     int64_t record_id;
     std::string content;

--- a/test-suite/generated-src/pycpp/color.hpp
+++ b/test-suite/generated-src/pycpp/color.hpp
@@ -11,6 +11,9 @@ enum class color : int {
     RED,
     ORANGE,
     YELLOW,
+    // "It is customary to list indigo as a color lying between blue and violet, but it has
+    // never seemed to me that indigo is worth the dignity of being considered a separate
+    // color. To my eyes it seems merely deep blue." --Isaac Asimov
     GREEN,
     BLUE,
     /**

--- a/test-suite/generated-src/pycpp/constants.cpp
+++ b/test-suite/generated-src/pycpp/constants.cpp
@@ -5,19 +5,19 @@
 
 namespace testsuite {
 
-bool const Constants::BOOL_CONSTANT;
+bool constexpr Constants::BOOL_CONSTANT;
 
-int8_t const Constants::I8_CONSTANT;
+int8_t constexpr Constants::I8_CONSTANT;
 
-int16_t const Constants::I16_CONSTANT;
+int16_t constexpr Constants::I16_CONSTANT;
 
-int32_t const Constants::I32_CONSTANT;
+int32_t constexpr Constants::I32_CONSTANT;
 
-int64_t const Constants::I64_CONSTANT;
+int64_t constexpr Constants::I64_CONSTANT;
 
-float const Constants::F32_CONSTANT;
+float constexpr Constants::F32_CONSTANT;
 
-double const Constants::F64_CONSTANT;
+double constexpr Constants::F64_CONSTANT;
 
 std::experimental::optional<bool> const Constants::OPT_BOOL_CONSTANT = true;
 
@@ -41,6 +41,6 @@ ConstantRecord const Constants::OBJECT_CONSTANT = ConstantRecord(
     Constants::I32_CONSTANT /* some_integer */ ,
     Constants::STRING_CONSTANT /* some_string */ );
 
-bool const Constants::DUMMY;
+bool constexpr Constants::DUMMY;
 
 }  // namespace testsuite

--- a/test-suite/generated-src/pycpp/constants.hpp
+++ b/test-suite/generated-src/pycpp/constants.hpp
@@ -17,6 +17,7 @@ struct Constants final {
     /** bool_constant has documentation. */
     static constexpr bool BOOL_CONSTANT = true;
 
+    // i8_constant has a comment
     static constexpr int8_t I8_CONSTANT = 1;
 
     static constexpr int16_t I16_CONSTANT = 2;
@@ -25,6 +26,9 @@ struct Constants final {
 
     static constexpr int64_t I64_CONSTANT = 4;
 
+    // f64_constant has a long comment.
+    // (Second line of multi-line comment.
+    //   Indented third line of multi-line comment.)
     static constexpr float F32_CONSTANT = 5.0f;
 
     /**
@@ -60,11 +64,9 @@ struct Constants final {
 
     static ConstantRecord const OBJECT_CONSTANT;
 
-    /**
-     * No support for null optional constants
-     * No support for optional constant records
-     * No support for constant binary, list, set, map
-     */
+    /** No support for null optional constants */
+    // No support for optional constant records
+    /** No support for constant binary, list, set, map */
     static constexpr bool DUMMY = false;
 };
 

--- a/test-suite/generated-src/pycpp/constants_interface.cpp
+++ b/test-suite/generated-src/pycpp/constants_interface.cpp
@@ -6,19 +6,19 @@
 
 namespace testsuite {
 
-bool const ConstantsInterface::BOOL_CONSTANT;
+bool constexpr ConstantsInterface::BOOL_CONSTANT;
 
-int8_t const ConstantsInterface::I8_CONSTANT;
+int8_t constexpr ConstantsInterface::I8_CONSTANT;
 
-int16_t const ConstantsInterface::I16_CONSTANT;
+int16_t constexpr ConstantsInterface::I16_CONSTANT;
 
-int32_t const ConstantsInterface::I32_CONSTANT;
+int32_t constexpr ConstantsInterface::I32_CONSTANT;
 
-int64_t const ConstantsInterface::I64_CONSTANT;
+int64_t constexpr ConstantsInterface::I64_CONSTANT;
 
-float const ConstantsInterface::F32_CONSTANT;
+float constexpr ConstantsInterface::F32_CONSTANT;
 
-double const ConstantsInterface::F64_CONSTANT;
+double constexpr ConstantsInterface::F64_CONSTANT;
 
 std::experimental::optional<bool> const ConstantsInterface::OPT_BOOL_CONSTANT = true;
 

--- a/test-suite/generated-src/pycpp/constants_interface.hpp
+++ b/test-suite/generated-src/pycpp/constants_interface.hpp
@@ -62,11 +62,9 @@ public:
 
     static ConstantRecord const OBJECT_CONSTANT;
 
-    /**
-     * No support for null optional constants
-     * No support for optional constant records
-     * No support for constant binary, list, set, map
-     */
+    // No support for null optional constants
+    /** No support for optional constant records */
+    // No support for constant binary, list, set, map
     virtual void dummy() = 0;
 };
 

--- a/test-suite/generated-src/pycpp/foo_constants.cpp
+++ b/test-suite/generated-src/pycpp/foo_constants.cpp
@@ -5,19 +5,19 @@
 
 namespace testsuite {
 
-bool const FooConstants::BOOL_CONSTANT;
+bool constexpr FooConstants::BOOL_CONSTANT;
 
-int8_t const FooConstants::I8_CONSTANT;
+int8_t constexpr FooConstants::I8_CONSTANT;
 
-int16_t const FooConstants::I16_CONSTANT;
+int16_t constexpr FooConstants::I16_CONSTANT;
 
-int32_t const FooConstants::I32_CONSTANT;
+int32_t constexpr FooConstants::I32_CONSTANT;
 
-int64_t const FooConstants::I64_CONSTANT;
+int64_t constexpr FooConstants::I64_CONSTANT;
 
-float const FooConstants::F32_CONSTANT;
+float constexpr FooConstants::F32_CONSTANT;
 
-double const FooConstants::F64_CONSTANT;
+double constexpr FooConstants::F64_CONSTANT;
 
 std::string const FooConstants::STRING_CONSTANT = {"string-constant"};
 

--- a/test-suite/generated-src/pycpp/foo_constants_interface.cpp
+++ b/test-suite/generated-src/pycpp/foo_constants_interface.cpp
@@ -6,19 +6,19 @@
 
 namespace testsuite {
 
-bool const FooConstantsInterface::BOOL_CONSTANT;
+bool constexpr FooConstantsInterface::BOOL_CONSTANT;
 
-int8_t const FooConstantsInterface::I8_CONSTANT;
+int8_t constexpr FooConstantsInterface::I8_CONSTANT;
 
-int16_t const FooConstantsInterface::I16_CONSTANT;
+int16_t constexpr FooConstantsInterface::I16_CONSTANT;
 
-int32_t const FooConstantsInterface::I32_CONSTANT;
+int32_t constexpr FooConstantsInterface::I32_CONSTANT;
 
-int64_t const FooConstantsInterface::I64_CONSTANT;
+int64_t constexpr FooConstantsInterface::I64_CONSTANT;
 
-float const FooConstantsInterface::F32_CONSTANT;
+float constexpr FooConstantsInterface::F32_CONSTANT;
 
-double const FooConstantsInterface::F64_CONSTANT;
+double constexpr FooConstantsInterface::F64_CONSTANT;
 
 std::experimental::optional<int32_t> const FooConstantsInterface::OPTIONAL_INTEGER_CONSTANT = 1;
 

--- a/test-suite/generated-src/pycpp/return_two.hpp
+++ b/test-suite/generated-src/pycpp/return_two.hpp
@@ -8,7 +8,7 @@
 
 namespace testsuite {
 
-/** Used for C++ multiple inheritance tests */
+// Used for C++ multiple inheritance tests
 class ReturnTwo {
 public:
     virtual ~ReturnTwo() {}

--- a/test-suite/generated-src/pycpp/reverse_client_interface.hpp
+++ b/test-suite/generated-src/pycpp/reverse_client_interface.hpp
@@ -15,8 +15,24 @@ public:
 
     virtual std::string return_str() const = 0;
 
+    // Testing code comments before documentation comments
+    // with multiple lines
+    // and another line
+    /**
+     * Testing documentation comments after code comments
+     * with multiple lines
+     * and another line
+     */
     virtual std::string meth_taking_interface(const std::shared_ptr<ReverseClientInterface> & i) = 0;
 
+    /**
+     * Testing documentation comments before code comments
+     * with multiple lines
+     * and another line
+     */
+    // Testing code comments after documentation comments
+    // with multiple lines
+    // and another line
     virtual std::string meth_taking_optional_interface(const std::shared_ptr<ReverseClientInterface> & i) = 0;
 
     static std::shared_ptr<ReverseClientInterface> create();

--- a/test-suite/generated-src/pycpp/second_listener.hpp
+++ b/test-suite/generated-src/pycpp/second_listener.hpp
@@ -5,7 +5,7 @@
 
 namespace testsuite {
 
-/** Used for non-C++ multiple inheritance tests */
+// Used for non-C++ multiple inheritance tests
 class SecondListener {
 public:
     virtual ~SecondListener() {}

--- a/test-suite/generated-src/python/client_interface.py
+++ b/test-suite/generated-src/python/client_interface.py
@@ -18,7 +18,10 @@ class ClientInterface(with_metaclass(ABCMeta)):
 
     @abstractmethod
     def get_record(self, record_id, utf8string, misc):
-        """ Returns record of given string """
+        """
+         Testing code comments before documentation comments
+         Returns record of given string
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -31,6 +34,10 @@ class ClientInterface(with_metaclass(ABCMeta)):
 
     @abstractmethod
     def meth_taking_interface(self, i):
+        """
+         Testing documentation comments before code comments
+         This method takes an interface
+        """
         raise NotImplementedError
 
     @abstractmethod

--- a/test-suite/generated-src/python/color.py
+++ b/test-suite/generated-src/python/color.py
@@ -13,6 +13,11 @@ class Color(IntEnum):
     Red = 0
     Orange = 1
     Yellow = 2
+    """
+     "It is customary to list indigo as a color lying between blue and violet, but it has
+     never seemed to me that indigo is worth the dignity of being considered a separate
+     color. To my eyes it seems merely deep blue." --Isaac Asimov
+    """
     Green = 3
     Blue = 4
     """

--- a/test-suite/generated-src/python/constants.py
+++ b/test-suite/generated-src/python/constants.py
@@ -16,11 +16,13 @@ class Constants:
      Record containing constants
     Constants
         BOOL_CONSTANT: bool_constant has documentation.
-        I8_CONSTANT
+        I8_CONSTANT: i8_constant has a comment
         I16_CONSTANT
         I32_CONSTANT
         I64_CONSTANT
-        F32_CONSTANT
+        F32_CONSTANT: f64_constant has a long comment.
+             (Second line of multi-line comment.
+               Indented third line of multi-line comment.)
         F64_CONSTANT: f64_constant has long documentation.
              (Second line of multi-line documentation.
                Indented third line of multi-line documentation.)

--- a/test-suite/generated-src/python/reverse_client_interface.py
+++ b/test-suite/generated-src/python/reverse_client_interface.py
@@ -18,10 +18,26 @@ class ReverseClientInterface(with_metaclass(ABCMeta)):
 
     @abstractmethod
     def meth_taking_interface(self, i):
+        """
+         Testing code comments before documentation comments
+         with multiple lines
+         and another line
+         Testing documentation comments after code comments
+         with multiple lines
+         and another line
+        """
         raise NotImplementedError
 
     @abstractmethod
     def meth_taking_optional_interface(self, i):
+        """
+         Testing documentation comments before code comments
+         with multiple lines
+         and another line
+         Testing code comments after documentation comments
+         with multiple lines
+         and another line
+        """
         raise NotImplementedError
 
     @staticmethod


### PR DESCRIPTION
After merging master branch to python branch, the python compile failed because of the update in #379.
So I made another commit 875bbe2 to update `PythonGenerator.scala`, so that it can make use of the updated Doc object