### PR TITLE
Provide a method to run functions on JVM thread

### DIFF
--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -28,6 +28,10 @@ namespace djinni {
 // Set only once from JNI_OnLoad before any other JNI calls, so no lock needed.
 static JavaVM * g_cachedJVM;
 
+JavaVM * getCachedJVM() {
+  return g_cachedJVM;
+}
+
 /*static*/
 JniClassInitializer::registration_vec & JniClassInitializer::get_vec() {
     static JniClassInitializer::registration_vec m;

--- a/support-lib/jni/djinni_support.hpp
+++ b/support-lib/jni/djinni_support.hpp
@@ -673,7 +673,7 @@ void jniDefaultSetPendingFromCurrent(JNIEnv * env, const char * ctx) noexcept;
  * it can safely be 0 for any function with a non-void return value.)
  */
 #define JNI_TRANSLATE_EXCEPTIONS_RETURN(env, ret) \
-    catch (const std::exception &e) { \
+    catch (const std::exception &) { \
         ::djinni::jniSetPendingFromCurrent(env, __func__); \
         return ret; \
     }


### PR DESCRIPTION
This is an attempt to provide a way for C++-created threads to call into Java without risking a memory leak, as requested in #176 . The basic idea is this:

- you pass in a lambda
- the current thread is attached to the JVM if it's not already
- the lambda is executed and the result, if any, stored
- the current thread is detached only if it was this function that attached it
- the result, if it was stored, is returned.

There are two functions because I'm not skilled enough with lambdas to make one function that will accept any kind of lambda.