### PR TITLE
Fix misleading README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ When the Djinni file(s) are ready, from the command line or a bash script you ca
        \
        --jni-out JNI_OUTPUT_FOLDER \
        --ident-jni-class NativeFooBar \ # This adds a "Native" prefix to JNI class
+       --ident-jni-file NativeFooBar \ # This adds a prefix to the JNI filenames otherwise the cpp and jni filenames are the same.
        \
        --objc-out OBJC_OUTPUT_FOLDER \
        --objc-type-prefix DB \ # Apple suggests Objective-C classes have a prefix for each defined type.

--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -72,7 +72,17 @@ void jniShutdown() {
 JNIEnv * jniGetThreadEnv() {
     assert(g_cachedJVM);
     JNIEnv * env = nullptr;
-    const jint get_res = g_cachedJVM->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
+    jint get_res = g_cachedJVM->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
+    #ifdef EXPERIMENTAL_AUTO_CPP_THREAD_ATTACH
+    if (get_res == JNI_EDETACHED) {
+        get_res = g_cachedJVM->AttachCurrentThread(&env, nullptr);
+        thread_local struct DetachOnExit {
+            ~DetachOnExit() {
+                g_cachedJVM->DetachCurrentThread();
+            }
+        } detachOnExit;
+    }
+    #endif
     if (get_res != 0 || !env) {
         // :(
         std::abort();


### PR DESCRIPTION
README instructions do not generate the files they say they will generate, fix the djinni command called so that they match up.