### PR TITLE
Change djinni's generated Java files to use interfaces

### DIFF
--- a/src/source/JNIMarshal.scala
+++ b/src/source/JNIMarshal.scala
@@ -70,9 +70,9 @@ class JNIMarshal(spec: Spec) extends Marshal(spec) {
         case MOptional => throw new AssertionError("nested optional?")
         case m => javaTypeSignature(tm.args.head)
       }
-      case MList => "Ljava/util/ArrayList;"
-      case MSet => "Ljava/util/HashSet;"
-      case MMap => "Ljava/util/HashMap;"
+      case MList => "Ljava/util/List;"
+      case MSet => "Ljava/util/Set;"
+      case MMap => "Ljava/util/Map;"
     }
     case e: MExtern => e.jni.typeSignature
     case MParam(_) => "Ljava/lang/Object;"

--- a/src/source/JavaMarshal.scala
+++ b/src/source/JavaMarshal.scala
@@ -30,9 +30,9 @@ class JavaMarshal(spec: Spec) extends Marshal(spec) {
   def references(m: Meta): Seq[SymbolReference] = m match {
     case o: MOpaque =>
       o match {
-        case MList => List(ImportRef("java.util.ArrayList"))
-        case MSet => List(ImportRef("java.util.HashSet"))
-        case MMap => List(ImportRef("java.util.HashMap"))
+        case MList => List(ImportRef("java.util.List"))
+        case MSet => List(ImportRef("java.util.Set"))
+        case MMap => List(ImportRef("java.util.Map"))
         case MDate => List(ImportRef("java.util.Date"))
         case _ => List()
       }
@@ -103,9 +103,9 @@ class JavaMarshal(spec: Spec) extends Marshal(spec) {
             case MDate => "Date"
             case MBinary => "byte[]"
             case MOptional => throw new AssertionError("optional should have been special cased")
-            case MList => "ArrayList"
-            case MSet => "HashSet"
-            case MMap => "HashMap"
+            case MList => "List"
+            case MSet => "Set"
+            case MMap => "Map"
             case d: MDef => withPackage(packageName, idJava.ty(d.name))
             case e: MExtern => throw new AssertionError("unreachable")
             case p: MParam => idJava.typeParam(p.name)


### PR DESCRIPTION
This pull request is related to https://github.com/dropbox/djinni/issues/390.
The idea is to use interfaces rather that classes as, anyway, the marshaling layer is ready for that.
This is a breaking change since users will need to update their overrides.