### PR TITLE
Fix misleading README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ When the Djinni file(s) are ready, from the command line or a bash script you ca
        \
        --jni-out JNI_OUTPUT_FOLDER \
        --ident-jni-class NativeFooBar \ # This adds a "Native" prefix to JNI class
+       --ident-jni-file NativeFooBar \ # This adds a prefix to the JNI filenames otherwise the cpp and jni filenames are the same.
        \
        --objc-out OBJC_OUTPUT_FOLDER \
        --objc-type-prefix DB \ # Apple suggests Objective-C classes have a prefix for each defined type.


### PR DESCRIPTION
README instructions do not generate the files they say they will generate, fix the djinni command called so that they match up.

Replaces #400 - apologies for duplicate pull request, I accidentally did the initial request from master instead of a branch and needed to free my master up for other changes.