### PR TITLE
Add cast to objective C convenience initializers to prevent naming co…

### DIFF
--- a/example/generated-src/objc/TXSItemList.mm
+++ b/example/generated-src/objc/TXSItemList.mm
@@ -16,7 +16,7 @@
 
 + (nonnull instancetype)itemListWithItems:(nonnull NSArray<NSString *> *)items
 {
-    return [[self alloc] initWithItems:items];
+    return [(TXSItemList*)[self alloc] initWithItems:items];
 }
 
 - (NSString *)description

--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -235,7 +235,7 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
         writeAlignedObjcCall(w, decl, r.fields, "", f => (idObjc.field(f.ident), s"(${marshal.paramType(f.ty)})${idObjc.local(f.ident)}"))
         w.wl
         w.braced {
-          val call = s"return [[self alloc] init$firstInitializerArg"
+          val call = s"return [($self*)[self alloc] init$firstInitializerArg"
           writeAlignedObjcCall(w, call, r.fields, "", f => (idObjc.field(f.ident), s"${idObjc.local(f.ident)}"))
           w.wl("];")
         }

--- a/test-suite/generated-src/objc/DBAssortedPrimitives.mm
+++ b/test-suite/generated-src/objc/DBAssortedPrimitives.mm
@@ -55,20 +55,20 @@
                                     oFthirtytwo:(nullable NSNumber *)oFthirtytwo
                                     oFsixtyfour:(nullable NSNumber *)oFsixtyfour
 {
-    return [[self alloc] initWithB:b
-                             eight:eight
-                           sixteen:sixteen
-                         thirtytwo:thirtytwo
-                         sixtyfour:sixtyfour
-                        fthirtytwo:fthirtytwo
-                        fsixtyfour:fsixtyfour
-                                oB:oB
-                            oEight:oEight
-                          oSixteen:oSixteen
-                        oThirtytwo:oThirtytwo
-                        oSixtyfour:oSixtyfour
-                       oFthirtytwo:oFthirtytwo
-                       oFsixtyfour:oFsixtyfour];
+    return [(DBAssortedPrimitives*)[self alloc] initWithB:b
+                                                    eight:eight
+                                                  sixteen:sixteen
+                                                thirtytwo:thirtytwo
+                                                sixtyfour:sixtyfour
+                                               fthirtytwo:fthirtytwo
+                                               fsixtyfour:fsixtyfour
+                                                       oB:oB
+                                                   oEight:oEight
+                                                 oSixteen:oSixteen
+                                               oThirtytwo:oThirtytwo
+                                               oSixtyfour:oSixtyfour
+                                              oFthirtytwo:oFthirtytwo
+                                              oFsixtyfour:oFsixtyfour];
 }
 
 - (BOOL)isEqual:(id)other

--- a/test-suite/generated-src/objc/DBClientReturnedRecord.mm
+++ b/test-suite/generated-src/objc/DBClientReturnedRecord.mm
@@ -22,9 +22,9 @@
                                                  content:(nonnull NSString *)content
                                                     misc:(nullable NSString *)misc
 {
-    return [[self alloc] initWithRecordId:recordId
-                                  content:content
-                                     misc:misc];
+    return [(DBClientReturnedRecord*)[self alloc] initWithRecordId:recordId
+                                                           content:content
+                                                              misc:misc];
 }
 
 - (NSString *)description

--- a/test-suite/generated-src/objc/DBConstantRecord.mm
+++ b/test-suite/generated-src/objc/DBConstantRecord.mm
@@ -19,8 +19,8 @@
 + (nonnull instancetype)constantRecordWithSomeInteger:(int32_t)someInteger
                                            someString:(nonnull NSString *)someString
 {
-    return [[self alloc] initWithSomeInteger:someInteger
-                                  someString:someString];
+    return [(DBConstantRecord*)[self alloc] initWithSomeInteger:someInteger
+                                                     someString:someString];
 }
 
 - (NSString *)description

--- a/test-suite/generated-src/objc/DBConstantWithEnum.mm
+++ b/test-suite/generated-src/objc/DBConstantWithEnum.mm
@@ -15,7 +15,7 @@
 
 + (nonnull instancetype)constantWithEnum
 {
-    return [[self alloc] init];
+    return [(DBConstantWithEnum*)[self alloc] init];
 }
 
 + (DBConstantEnum)constEnum

--- a/test-suite/generated-src/objc/DBConstants.mm
+++ b/test-suite/generated-src/objc/DBConstants.mm
@@ -35,7 +35,7 @@ BOOL const DBConstantsDummy = NO;
 
 + (nonnull instancetype)constants
 {
-    return [[self alloc] init];
+    return [(DBConstants*)[self alloc] init];
 }
 
 + (NSNumber * __nullable)optBoolConstant

--- a/test-suite/generated-src/objc/DBDateRecord.mm
+++ b/test-suite/generated-src/objc/DBDateRecord.mm
@@ -16,7 +16,7 @@
 
 + (nonnull instancetype)dateRecordWithCreatedAt:(nonnull NSDate *)createdAt
 {
-    return [[self alloc] initWithCreatedAt:createdAt];
+    return [(DBDateRecord*)[self alloc] initWithCreatedAt:createdAt];
 }
 
 - (BOOL)isEqual:(id)other

--- a/test-suite/generated-src/objc/DBEmptyRecord.mm
+++ b/test-suite/generated-src/objc/DBEmptyRecord.mm
@@ -15,7 +15,7 @@
 
 + (nonnull instancetype)emptyRecord
 {
-    return [[self alloc] init];
+    return [(DBEmptyRecord*)[self alloc] init];
 }
 
 - (NSString *)description

--- a/test-suite/generated-src/objc/DBEnumUsageRecord.mm
+++ b/test-suite/generated-src/objc/DBEnumUsageRecord.mm
@@ -28,11 +28,11 @@
                                            s:(nonnull NSSet<NSNumber *> *)s
                                            m:(nonnull NSDictionary<NSNumber *, NSNumber *> *)m
 {
-    return [[self alloc] initWithE:e
-                                 o:o
-                                 l:l
-                                 s:s
-                                 m:m];
+    return [(DBEnumUsageRecord*)[self alloc] initWithE:e
+                                                     o:o
+                                                     l:l
+                                                     s:s
+                                                     m:m];
 }
 
 - (NSString *)description

--- a/test-suite/generated-src/objc/DBExtendedRecord.mm
+++ b/test-suite/generated-src/objc/DBExtendedRecord.mm
@@ -16,7 +16,7 @@
 
 + (nonnull instancetype)extendedRecordWithFoo:(BOOL)foo
 {
-    return [[self alloc] initWithFoo:foo];
+    return [(DBExtendedRecord*)[self alloc] initWithFoo:foo];
 }
 
 + (DBExtendedRecord * __nonnull)extendedRecordConst

--- a/test-suite/generated-src/objc/DBExternRecordWithDerivings.mm
+++ b/test-suite/generated-src/objc/DBExternRecordWithDerivings.mm
@@ -19,8 +19,8 @@
 + (nonnull instancetype)externRecordWithDerivingsWithMember:(nonnull DBRecordWithDerivings *)member
                                                           e:(DBColor)e
 {
-    return [[self alloc] initWithMember:member
-                                      e:e];
+    return [(DBExternRecordWithDerivings*)[self alloc] initWithMember:member
+                                                                    e:e];
 }
 
 - (BOOL)isEqual:(id)other

--- a/test-suite/generated-src/objc/DBMapDateRecord.mm
+++ b/test-suite/generated-src/objc/DBMapDateRecord.mm
@@ -16,7 +16,7 @@
 
 + (nonnull instancetype)mapDateRecordWithDatesById:(nonnull NSDictionary<NSString *, NSDate *> *)datesById
 {
-    return [[self alloc] initWithDatesById:datesById];
+    return [(DBMapDateRecord*)[self alloc] initWithDatesById:datesById];
 }
 
 - (NSString *)description

--- a/test-suite/generated-src/objc/DBMapListRecord.mm
+++ b/test-suite/generated-src/objc/DBMapListRecord.mm
@@ -16,7 +16,7 @@
 
 + (nonnull instancetype)mapListRecordWithMapList:(nonnull NSArray<NSDictionary<NSString *, NSNumber *> *> *)mapList
 {
-    return [[self alloc] initWithMapList:mapList];
+    return [(DBMapListRecord*)[self alloc] initWithMapList:mapList];
 }
 
 - (NSString *)description

--- a/test-suite/generated-src/objc/DBMapRecord.mm
+++ b/test-suite/generated-src/objc/DBMapRecord.mm
@@ -19,8 +19,8 @@
 + (nonnull instancetype)mapRecordWithMap:(nonnull NSDictionary<NSString *, NSNumber *> *)map
                                     imap:(nonnull NSDictionary<NSNumber *, NSNumber *> *)imap
 {
-    return [[self alloc] initWithMap:map
-                                imap:imap];
+    return [(DBMapRecord*)[self alloc] initWithMap:map
+                                              imap:imap];
 }
 
 - (NSString *)description

--- a/test-suite/generated-src/objc/DBNestedCollection.mm
+++ b/test-suite/generated-src/objc/DBNestedCollection.mm
@@ -16,7 +16,7 @@
 
 + (nonnull instancetype)nestedCollectionWithSetList:(nonnull NSArray<NSSet<NSString *> *> *)setList
 {
-    return [[self alloc] initWithSetList:setList];
+    return [(DBNestedCollection*)[self alloc] initWithSetList:setList];
 }
 
 - (NSString *)description

--- a/test-suite/generated-src/objc/DBPrimitiveList.mm
+++ b/test-suite/generated-src/objc/DBPrimitiveList.mm
@@ -16,7 +16,7 @@
 
 + (nonnull instancetype)primitiveListWithList:(nonnull NSArray<NSNumber *> *)list
 {
-    return [[self alloc] initWithList:list];
+    return [(DBPrimitiveList*)[self alloc] initWithList:list];
 }
 
 - (NSString *)description

--- a/test-suite/generated-src/objc/DBRecordUsingExtendedRecord.mm
+++ b/test-suite/generated-src/objc/DBRecordUsingExtendedRecord.mm
@@ -16,7 +16,7 @@
 
 + (nonnull instancetype)recordUsingExtendedRecordWithEr:(nonnull DBExtendedRecord *)er
 {
-    return [[self alloc] initWithEr:er];
+    return [(DBRecordUsingExtendedRecord*)[self alloc] initWithEr:er];
 }
 
 + (DBRecordUsingExtendedRecord * __nonnull)cr

--- a/test-suite/generated-src/objc/DBRecordWithDerivings.mm
+++ b/test-suite/generated-src/objc/DBRecordWithDerivings.mm
@@ -37,14 +37,14 @@
                                                    d:(nonnull NSDate *)d
                                                    s:(nonnull NSString *)s
 {
-    return [[self alloc] initWithEight:eight
-                               sixteen:sixteen
-                             thirtytwo:thirtytwo
-                             sixtyfour:sixtyfour
-                            fthirtytwo:fthirtytwo
-                            fsixtyfour:fsixtyfour
-                                     d:d
-                                     s:s];
+    return [(DBRecordWithDerivings*)[self alloc] initWithEight:eight
+                                                       sixteen:sixteen
+                                                     thirtytwo:thirtytwo
+                                                     sixtyfour:sixtyfour
+                                                    fthirtytwo:fthirtytwo
+                                                    fsixtyfour:fsixtyfour
+                                                             d:d
+                                                             s:s];
 }
 
 - (BOOL)isEqual:(id)other

--- a/test-suite/generated-src/objc/DBRecordWithDurationAndDerivings.mm
+++ b/test-suite/generated-src/objc/DBRecordWithDurationAndDerivings.mm
@@ -16,7 +16,7 @@
 
 + (nonnull instancetype)recordWithDurationAndDerivingsWithDt:(NSTimeInterval)dt
 {
-    return [[self alloc] initWithDt:dt];
+    return [(DBRecordWithDurationAndDerivings*)[self alloc] initWithDt:dt];
 }
 
 - (BOOL)isEqual:(id)other

--- a/test-suite/generated-src/objc/DBRecordWithFlags.mm
+++ b/test-suite/generated-src/objc/DBRecordWithFlags.mm
@@ -16,7 +16,7 @@
 
 + (nonnull instancetype)recordWithFlagsWithAccess:(DBAccessFlags)access
 {
-    return [[self alloc] initWithAccess:access];
+    return [(DBRecordWithFlags*)[self alloc] initWithAccess:access];
 }
 
 - (NSString *)description

--- a/test-suite/generated-src/objc/DBRecordWithNestedDerivings.mm
+++ b/test-suite/generated-src/objc/DBRecordWithNestedDerivings.mm
@@ -19,8 +19,8 @@
 + (nonnull instancetype)recordWithNestedDerivingsWithKey:(int32_t)key
                                                      rec:(nonnull DBRecordWithDerivings *)rec
 {
-    return [[self alloc] initWithKey:key
-                                 rec:rec];
+    return [(DBRecordWithNestedDerivings*)[self alloc] initWithKey:key
+                                                               rec:rec];
 }
 
 - (BOOL)isEqual:(id)other

--- a/test-suite/generated-src/objc/DBSetRecord.mm
+++ b/test-suite/generated-src/objc/DBSetRecord.mm
@@ -19,8 +19,8 @@
 + (nonnull instancetype)setRecordWithSet:(nonnull NSSet<NSString *> *)set
                                     iset:(nonnull NSSet<NSNumber *> *)iset
 {
-    return [[self alloc] initWithSet:set
-                                iset:iset];
+    return [(DBSetRecord*)[self alloc] initWithSet:set
+                                              iset:iset];
 }
 
 - (NSString *)description

--- a/test-suite/generated-src/objc/DBVarnameRecord.mm
+++ b/test-suite/generated-src/objc/DBVarnameRecord.mm
@@ -16,7 +16,7 @@
 
 + (nonnull instancetype)VarnameRecordWithField:(int8_t)Field
 {
-    return [[self alloc] initWithField:Field];
+    return [(DBVarnameRecord*)[self alloc] initWithField:Field];
 }
 
 - (NSString *)description

--- a/test-suite/generated-src/objc/DBWcharTestRec.mm
+++ b/test-suite/generated-src/objc/DBWcharTestRec.mm
@@ -16,7 +16,7 @@
 
 + (nonnull instancetype)wcharTestRecWithS:(nonnull NSString *)s
 {
-    return [[self alloc] initWithS:s];
+    return [(DBWcharTestRec*)[self alloc] initWithS:s];
 }
 
 - (NSString *)description


### PR DESCRIPTION
In generated Objective C code, convenience initializers can easily cause naming collisions with built in ios functions and other code that follows the same naming pattern.  As a trivial example, consider the following record:

`MyColor = record
{
    red : f32;
    green : f32;
    blue : f32;
    alpha : f32;
} deriving( eq )`



This produces a function that looks something like this:
` (nonnull instancetype)MyColorWithRed:(float)red
{
(nonnull instancetype)MyColor:(float)red
                                   green:(float)green
                                    blue:(float)blue
                                   alpha:(float)alpha
{
    return [[self alloc] initWithRed:red
                                                green:green
                                                 blue:blue
                                                alpha:alpha];
}
}`

If your project happens to include UIKit, this generated code will emit a compilation error because InitWithRed is defined in UIKit (see https://developer.apple.com/documentation/uikit/uicolor/1621925-initwithred?language=objc) and without qualification, the call is ambiguous.

Adding a cast to the generated code disambiguates the call to initWithRed (and other similar situations)