### PR TITLE
Add the ability to get the JavaVM

### DIFF
--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -69,6 +69,10 @@ void jniShutdown() {
     g_cachedJVM = nullptr;
 }
 
+JavaVM * jniGetVM() {
+    return g_cachedJVM;
+}
+
 JNIEnv * jniGetThreadEnv() {
     assert(g_cachedJVM);
     JNIEnv * env = nullptr;
@@ -594,6 +598,8 @@ void jniDefaultSetPendingFromCurrentImpl(JNIEnv * env) {
         return;
     } catch (const std::exception & e) {
         env->ThrowNew(env->FindClass("java/lang/RuntimeException"), e.what());
+    } catch(...) {
+        std::terminate();
     }
 }
 

--- a/support-lib/jni/djinni_support.hpp
+++ b/support-lib/jni/djinni_support.hpp
@@ -43,6 +43,13 @@ void jniInit(JavaVM * jvm);
 void jniShutdown();
 
 /*
+ * Get the JavaVM which was registered in the onload for e.g. forwarding to other libraries
+ * 
+ */
+
+JavaVM * jniGetVM();
+
+/*
  * Get the JNIEnv for the invoking thread. Should only be called on Java-created threads.
  */
 JNIEnv * jniGetThreadEnv();


### PR DESCRIPTION
Add the ability to get the JavaVM which was registered in the onload for e.g. forwarding to other libraries