### PR TITLE
Fix deprecation warning when running the build script

### DIFF
--- a/src/build.sbt
+++ b/src/build.sbt
@@ -17,4 +17,4 @@ scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Xmax-classfile
 
 libraryDependencies += "com.github.scopt" %% "scopt" % "3.2.0"
 
-seq(SbtStartScript.startScriptForClassesSettings: _*)
+Seq(SbtStartScript.startScriptForClassesSettings: _*)


### PR DESCRIPTION
The following build warning is emitted when running src/build:

src/build.sbt:20: warning: method seq in trait BuildExtra is deprecated: In build.sbt files, this call can be removed.  In other cases, this can usually be replaced by Seq.
seq(SbtStartScript.startScriptForClassesSettings: _*)

The call cannot be removed without breaking the build script, but changing "seq" to "Seq" seems to do the trick.

Running make does not change to any of the existing test or example files.  All test cases pass.