### PR TITLE
Improve error messages and generate operator<< for records

### DIFF
--- a/example/generated-src/cpp/sort_order.hpp
+++ b/example/generated-src/cpp/sort_order.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <functional>
+#include <ostream>
 
 namespace textsort {
 
@@ -12,6 +13,16 @@ enum class sort_order : int {
     DESCENDING,
     RANDOM,
 };
+
+static inline ::std::ostream& operator<<(::std::ostream& os, sort_order v) {
+    os << "sort_order::";
+    switch (v) {
+        case sort_order::ASCENDING: return os << "ASCENDING";
+        case sort_order::DESCENDING: return os << "DESCENDING";
+        case sort_order::RANDOM: return os << "RANDOM";
+        default: return os << "<Unsupported Value " << static_cast<int>(v) << ">";
+    }
+}
 
 }  // namespace textsort
 

--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -260,7 +260,7 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
 
     writeHppFile(cppName, origin, refs.hpp, refs.hppFwds, writeCppPrototype)
 
-    if (r.consts.nonEmpty || r.derivingTypes.contains(DerivingType.Eq) || r.derivingTypes.contains(DerivingType.Ord)) {
+    if (r.consts.nonEmpty || r.derivingTypes.contains(DerivingType.Eq) || r.derivingTypes.contains(DerivingType.Ord) || r.derivingTypes.contains(DerivingType.Show)) {
       writeCppFile(cppName, origin, refs.cpp, w => {
         generateCppConstants(w, r.consts, actualSelf)
 
@@ -306,6 +306,16 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
           w.w(s"bool operator>=(const $actualSelf& lhs, const $actualSelf& rhs)").braced {
             w.wl("return !(lhs < rhs);")
           }
+        }
+        if (r.derivingTypes.contains(DerivingType.Show)) {
+            w.wl
+            w.w(s"::std::ostream& operator<<(::std::ostream& os, const $actualSelf& self)").braced {
+                w.wl("os << \"" ++ self ++ "{\";")
+                for(f <- r.fields) {
+                    w.wl("os << \" " ++ idCpp.field(f.ident) ++ ":\" << self." ++ idCpp.field(f.ident) ++ ";")
+                }
+                w.wl("return os << \"}\";")
+            }
         }
       })
     }

--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -204,6 +204,9 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
     r.fields.foreach(f => refs.find(f.ty, false))
     r.consts.foreach(c => refs.find(c.ty, false))
     refs.hpp.add("#include <utility>") // Add for std::move
+    if (r.derivingTypes.contains(DerivingType.Show)) {
+      refs.hpp.add("#include <ostream>") // Add for overloading operator<<
+    }
 
     val self = marshal.typename(ident, r)
     val (cppName, cppFinal) = if (r.ext.cpp) (ident.name + "_base", "") else (ident.name, " final")
@@ -246,6 +249,10 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
           w.wl(s"friend bool operator<=(const $actualSelf& lhs, const $actualSelf& rhs);")
           w.wl(s"friend bool operator>=(const $actualSelf& lhs, const $actualSelf& rhs);")
         }
+        if (r.derivingTypes.contains(DerivingType.Show)) {
+          w.wl
+          w.wl(s"friend ::std::ostream& operator<<(::std::ostream& os, const $actualSelf& self);")
+        }
 
         // Constructor.
         if(r.fields.nonEmpty) {
@@ -270,6 +277,11 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
           w.wl(s"$actualSelf& operator=(const $actualSelf&) = default;")
           w.wl(s"$actualSelf& operator=($actualSelf&&) = default;")
         }
+      }
+
+      if (r.derivingTypes.contains(DerivingType.Show)) {
+        w.wl
+        w.wl(s"::std::ostream& operator<<(::std::ostream& os, const $actualSelf& self);")
       }
     }
 
@@ -323,14 +335,44 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
           }
         }
         if (r.derivingTypes.contains(DerivingType.Show)) {
-            w.wl
-            w.w(s"::std::ostream& operator<<(::std::ostream& os, const $actualSelf& self)").braced {
-                w.wl("os << \"" ++ self ++ "{\";")
-                for(f <- r.fields) {
-                    w.wl("os << \" " ++ idCpp.field(f.ident) ++ ":\" << self." ++ idCpp.field(f.ident) ++ ";")
+          def generateCollectionFormatterIfNeeded(parameters: Array[String], collection: String, open: String, close: String) {
+            // overload operator<< for collections that are actually used
+            if (refs.hpp.contains(s"#include <$collection>")) {
+              def chain(a: String, b: String): String = {
+                a ++ ", " ++ b
+              }
+
+              val parameterDecl = parameters.map(p => "typename " ++ p).reduceLeft(chain)
+              w.wl(s"template<$parameterDecl>")
+
+              val parameterDef = parameters.reduceLeft(chain)
+              val collectionDecl = s"::std::$collection<$parameterDef>"
+              w.w(s"::std::ostream& operator<<(::std::ostream& os, const $collectionDecl& c)").braced {
+                w.wl("auto first = true;")
+                w.wl("os << \"" ++ open ++ "\";")
+                w.w("for (auto&& element : c)").braced {
+                  w.wl("if (first) first = false; else os << \",\" << ::std::endl;")
+                  parameters.length match {
+                    case 1 => w.wl("os << element;")
+                    case 2 => w.wl("os << element.first << \": \" << element.second;")
+                  }
                 }
-                w.wl("return os << \"}\";")
+                w.wl("return os << \"" ++ close ++ "\";")
+              }
             }
+          }
+          generateCollectionFormatterIfNeeded(Array("T"), "vector", "[", "]")
+          generateCollectionFormatterIfNeeded(Array("T"), "unordered_set", "{", "}")
+          generateCollectionFormatterIfNeeded(Array("K","V"), "unordered_map", "[", "]")
+
+          w.wl
+          w.w(s"::std::ostream& operator<<(::std::ostream& os, const $actualSelf& self)").braced {
+            w.wl("os << \"" ++ self ++ "{\";")
+            for(f <- r.fields) {
+              w.wl("os << \" " ++ idCpp.field(f.ident) ++ ":\" << self." ++ idCpp.field(f.ident) ++ ";")
+            }
+            w.wl("return os << \"}\";")
+          }
         }
       })
     }

--- a/src/source/ast.scala
+++ b/src/source/ast.scala
@@ -75,7 +75,7 @@ case class Record(ext: Ext, fields: Seq[Field], consts: Seq[Const], derivingType
 object Record {
   object DerivingType extends Enumeration {
     type DerivingType = Value
-    val Eq, Ord, AndroidParcelable = Value
+    val Eq, Ord, Show, AndroidParcelable = Value
   }
 }
 

--- a/src/source/parser.scala
+++ b/src/source/parser.scala
@@ -123,6 +123,7 @@ private object IdlParser extends RegexParsers {
     _.map(ident => ident.name match {
       case "eq" => Record.DerivingType.Eq
       case "ord" => Record.DerivingType.Ord
+      case "show" => Record.DerivingType.Show
       case "parcelable" => Record.DerivingType.AndroidParcelable
       case _ => return err( s"""Unrecognized deriving type "${ident.name}"""")
     }).toSet


### PR DESCRIPTION
This PR improves the error messages when a record cannot conform to a typeclass, because it has fields of types that don’t. In addition, it generates the C++ `operator<<` for enums, and introduces the `show` typeclass to do the same for records `deriving (show)`.

Assuming the following Djinni file:
```
enum CurrencyCode {
    USD;
    EUR;
};

Amount = record {
    units: i64;
    currency: CurrencyCode;
} deriving (show)

Product = record {
    name: string;
    identifier: string;
    price: Amount;
} deriving (show)

ShoppingCart = record {
    items: list<Product>;
} deriving (show)
```

This PR allows you to write the following C++ code:
```c++
Product p{"Little Red Corvette", "v0KpfrJE4zw", Amount{1999, CurrencyCode::USD}};
Product q{"Breakfast Can Wait", "CzWX1gv6u2s", Amount{2013, CurrencyCode::EUR}};
ShoppingCart c{{p, q}};
std::cout << c << std::endl;
/* prints
"""ShoppingCart{ items:[
Product{ name:Little Red Corvette, identifier:v0KpfrJE4zw, price:Amount{ units:1999, currency:CurrencyCode::USD } },
Product{ name:Breakfast Can Wait, identifier:CzWX1gv6u2s, price:Amount{ units:2013, currency:CurrencyCode::EUR } },
] }"""
 */
```

If `Amount` would be missing the declaration of conformance to `show`, the error message from running Djinni would clearly say so:

```
Record 'Amount' not deriving required operation(s): 'show'
```

## Supported Field Types

- any record `deriving (show)`
- numbers and strings
- any `enum`
- any `list<T>` where `T` is any of the above (or a map, or a list)
- any `map<K,V>` where `K` and `V` are any of the above (or a map)

## Limitations/Known Issues

- `data` fields are printed as arrays of integers by default
- `flag` and `optional` fields require handwritten overloads of `operator<<` to be available in the translation unit of the record; failure to do so will not report an error until trying to compile the record’s `.cpp`file
- no specific error checking/reporting is implemented for containers: if the contained type doesn’t support `show`, the error may not surface until trying to compile the record’s `.cpp` file
- the added code is most definitely not idiomatic Scala, but rather baby steps towards learning the language