### PR TITLE
Add support for running Djinni with Git Bash on Windows 

### DIFF
--- a/src/run
+++ b/src/run
@@ -19,7 +19,7 @@ base_dir=$(cd "`dirname "$loc"`" > /dev/null && pwd)
 # Determine os version and choose correspondent .sh or .bat file accordingly.
 os_version="`uname -a`"
 
-if [[ $os_version == *"MINGW"* ]]; then  
+if [[ $os_version == *"MINGW"* ]] || [[ $os_version == *"MSYS_NT"* ]]; then  
   cmd //C "$base_dir/target/start.bat" "$@"
 else  
   exec "$base_dir/target/start" "$@"


### PR DESCRIPTION
When running with git bash, the platform is `MSYS_NT` so a conditional had to be added to allow generation to run the correct batch file when using this platform.  