### PR TITLE
Make "const auto" where variable not being modified and ask about (void).

### DIFF
--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -283,7 +283,7 @@ JniFlags::JniFlags(const std::string & name)
 
 unsigned JniFlags::flags(JNIEnv * env, jobject obj) const {
     DJINNI_ASSERT(obj && env->IsInstanceOf(obj, m_clazz.get()), env);
-    auto size = env->CallIntMethod(obj, m_methSize);
+    const auto size = env->CallIntMethod(obj, m_methSize);
     jniExceptionCheck(env);
     unsigned flags = 0;
     auto it = LocalRef<jobject>(env, env->CallObjectMethod(obj, m_methIterator));


### PR DESCRIPTION
Hello, first of all I would like to thank the folks who have contributed to this code base, I have never explored a more beautifully written C++ code base!!

Here is a small change that kind of was triggering my coding OCD :,). I don't think ```size``` gets modified anywhere so I made it const (please correct me if I am wrong).

Moreover, if time permits I would really appreciate if a few of my curiosities can be answered (for learning purposes):

on line ```466``` and ```467``` of ```djinni_support.cpp``` we have the following:
```cpp
    (void)implWStringToUTF16<2>;
    (void)implWStringToUTF16<4>;
```
Could we not change the ```(void)``` to one of the following solutions ? or is there something wrong with them? and why is ```(void)``` more useful over them.

- SOLUTION 1: Template Function
```cpp
// some_helper.h
template<typename T> inline void ignore(const T&) {}
```
```cpp
include "some_helper.h"
...
    ignore(implWStringToUTF16<2>);
    ignore(implWStringToUTF16<4>);
...
```

- SOLUTION 2: C++ Attribute
```cpp
    [[maybe_unused]] implWStringToUTF16<2>;
    [[maybe_unused]] implWStringToUTF16<4>;
```

- SOLUTION 3: Static Casts to ```void```.
```cpp
    static_cast<void>(implWStringToUTF16<2>);
    static_cast<void>(implWStringToUTF16<4>);
```

- SOLUTION 4: Static Casts to ```const void```.
```cpp
    static_cast<const void>(implWStringToUTF16<2>);
    static_cast<const void>(implWStringToUTF16<4>);
```

- SOLUTION 5: Static Casts to ```volatile void```.
```cpp
    static_cast<volatile void>(implWStringToUTF16<2>);
    static_cast<volatile void>(implWStringToUTF16<4>);
```