### PR TITLE
static libraries should set SKIP_INSTALL=YES in XCode builds

### DIFF
--- a/extension-libs/platform-threads/platform-threads.gyp
+++ b/extension-libs/platform-threads/platform-threads.gyp
@@ -14,12 +14,16 @@
                   "cpp",
                 ],
             },
+            "xcode_settings": {
+              "SKIP_INSTALL": "YES",
+            },
         },
         {
             "target_name": "thread_objc",
             "type": "static_library",
             "xcode_settings": {
               "CLANG_ENABLE_OBJC_ARC": "YES",
+              "SKIP_INSTALL": "YES",
             },
             "sources": [
               "objc/DJIThreadFactoryImpl.h",

--- a/support-lib/support_lib.gyp
+++ b/support-lib/support_lib.gyp
@@ -17,6 +17,9 @@
           "jni",
         ],
       },
+      "xcode_settings": {
+        "SKIP_INSTALL": "YES",
+      },
     },
     {
       "target_name": "djinni_jni_main",
@@ -29,12 +32,16 @@
           "LOCAL_WHOLE_STATIC_LIBRARIES": [ 'djinni_jni_main' ], # Ensure JNI symbols are exposed
         },
       },
+      "xcode_settings": {
+        "SKIP_INSTALL": "YES",
+      },
     },
     {
       "target_name": "djinni_objc",
       "type": "static_library",
       "xcode_settings": {
         "CLANG_ENABLE_OBJC_ARC": "YES",
+        "SKIP_INSTALL": "YES",
       },
       "sources": [
         "objc/DJICppWrapperCache+Private.h",


### PR DESCRIPTION
Every time I try to generate an iOS App archive from XCode, I run into the problem that XCode doesn't recognize the archive as an iOS App because SKIPS_INSTALL isn't set of the Djinni support lib targets. [Here's an Apple technical note explaining](https://developer.apple.com/library/archive/technotes/tn2215/_index.html).

I think the Djinni support lib targets should always be static libraries, so I think this is the right behavior to have by default. Also, I'm hoping that others won't be tripped up like I was since XCode provides no feedback in debugging why an archive isn't considered an iOS App.