### PR TITLE
Fix build Android example project

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -4,7 +4,7 @@
     # enable android short names (not full paths) for linking libraries
     "android_unmangled_name": 1,
     'cflags':    [ '-gdwarf-2', '-Werror', '-Wall', '-Wextra', '-Wno-missing-field-initializers' ],
-    'cflags_cc': [ '-std=c++11', '-frtti', '-fexceptions', '-Wno-literal-suffix' ],
+    'cflags_cc': [ '-std=c++11', '-frtti', '-fexceptions' ],
     'xcode_settings': {
       'OTHER_CFLAGS' : ['-Wall'],
       'OTHER_CPLUSPLUSFLAGS' : ['-Wall'],

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 28
 
     defaultConfig {
         applicationId "com.dropbox.textsort"
-        minSdkVersion 15
-        targetSdkVersion 23
+        minSdkVersion 16
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -33,7 +33,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.google.code.findbugs:jsr305:3.0.0'
+    implementation 'com.google.code.findbugs:jsr305:3.0.2'
 }
 
 task ndkBuild(type: Exec) {

--- a/example/android/app/jni/Application.mk
+++ b/example/android/app/jni/Application.mk
@@ -2,10 +2,10 @@
 
 APP_ABI := all
 APP_OPTIM := release
-APP_PLATFORM := android-8
-# GCC 4.9 Toolchain - requires NDK r10
-NDK_TOOLCHAIN_VERSION = 4.9
-# GNU libc++ is the only Android STL which supports C++11 features
-APP_STL := gnustl_static
+# Android NDK: android-8 is unsupported. Using minimum supported version android-16.
+APP_PLATFORM := android-16
+# Android NDK: Invalid NDK_TOOLCHAIN_VERSION value: 4.9. GCC is no longer supported. See https://android.googlesource.com/platform/ndk/+/master/docs/ClangMigration.md.
+# Android NDK: APP_STL gnustl_static is no longer supported. Please switch to either c++_static or c++_shared. See https://developer.android.com/ndk/guides/cpp-support.html for more information.
+APP_STL := c++_static
 APP_BUILD_SCRIPT := jni/Android.mk
 APP_MODULES := libtextsort_jni

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,6 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip


### PR DESCRIPTION
The Android example project it's not building anymore due to multiple incompatibilidades with the last Android Studio release 3.3.2 as today.
So I fix all the issues, because this was not letting me run the command `make all` with success.
Where it was possible I created a comment near the issue, showing the error, for future documentation on why things changed.