### PR TITLE
Fix some issues with parcelable code gen with enums and flags

### DIFF
--- a/example/example.djinni
+++ b/example/example.djinni
@@ -1,6 +1,6 @@
 item_list = record {
     items: list<string>;
-}
+} deriving(parcelable)
 
 sort_order = enum {
     ascending;

--- a/example/example.djinni
+++ b/example/example.djinni
@@ -1,6 +1,6 @@
 item_list = record {
     items: list<string>;
-} deriving(parcelable)
+}
 
 sort_order = enum {
     ascending;

--- a/example/run_djinni.sh
+++ b/example/run_djinni.sh
@@ -55,6 +55,7 @@ fi
     --java-package $java_package \
     --java-class-access-modifier "package" \
     --java-generate-interfaces true \
+    --java-implement-android-os-parcelable true \
     --java-nullable-annotation "javax.annotation.CheckForNull" \
     --java-nonnull-annotation "javax.annotation.Nonnull" \
     --ident-java-field mFooBar \

--- a/example/run_djinni.sh
+++ b/example/run_djinni.sh
@@ -55,7 +55,6 @@ fi
     --java-package $java_package \
     --java-class-access-modifier "package" \
     --java-generate-interfaces true \
-    --java-implement-android-os-parcelable true \
     --java-nullable-annotation "javax.annotation.CheckForNull" \
     --java-nonnull-annotation "javax.annotation.Nonnull" \
     --ident-java-field mFooBar \

--- a/src/source/JavaGenerator.scala
+++ b/src/source/JavaGenerator.scala
@@ -482,12 +482,24 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
         }
         case df: MDef => df.defType match {
           case DRecord => w.wl(s"this.${idJava.field(f.ident)} = new ${marshal.typename(f.ty)}(in);")
-          case DEnum => w.wl(s"this.${idJava.field(f.ident)} = ${marshal.typename(f.ty)}.values()[in.readInt()];")
+          case DEnum => {
+            if(marshal.isEnumFlags(m)) {
+              w.wl(s"this.${idJava.field(f.ident)} = (EnumSet<${marshal.typename(f.ty)}>) in.readSerializable();")
+            } else {
+              w.wl(s"this.${idJava.field(f.ident)} = ${marshal.typename(f.ty)}.values()[in.readInt()];")
+            }
+          }
           case _ => throw new AssertionError("Unreachable")
         }
         case e: MExtern => e.defType match {
           case DRecord => w.wl(s"this.${idJava.field(f.ident)} = ${e.java.readFromParcel.format(marshal.typename(f.ty))};")
-          case DEnum => w.wl(s"this.${idJava.field(f.ident)} = ${marshal.typename(f.ty)}.values()[in.readInt()];")
+          case DEnum => {
+            if(marshal.isEnumFlags(m)) {
+              w.wl(s"this.${idJava.field(f.ident)} = (EnumSet<${marshal.typename(f.ty)}>) in.readSerializable();")
+            } else {
+              w.wl(s"this.${idJava.field(f.ident)} = ${marshal.typename(f.ty)}.values()[in.readInt()];")
+            }
+          }
           case _ => throw new AssertionError("Unreachable")
         }
         case MList => {
@@ -550,12 +562,24 @@ class JavaGenerator(spec: Spec) extends Generator(spec) {
         }
         case df: MDef => df.defType match {
           case DRecord => w.wl(s"this.${idJava.field(f.ident)}.writeToParcel(out, flags);")
-          case DEnum => w.wl(s"out.writeInt(this.${idJava.field(f.ident)}.ordinal());")
+          case DEnum => {
+            if(marshal.isEnumFlags(m)) {
+              w.wl(s"out.writeSerializable(this.${idJava.field(f.ident)});")
+            } else {
+              w.wl(s"out.writeInt(this.${idJava.field(f.ident)}.ordinal());")
+            }
+          }
           case _ => throw new AssertionError("Unreachable")
         }
         case e: MExtern => e.defType match {
           case DRecord => w.wl(e.java.writeToParcel.format(idJava.field(f.ident)) + ";")
-          case DEnum => w.wl(s"out.writeInt((int)this.${idJava.field(f.ident)});")
+          case DEnum => {
+            if(marshal.isEnumFlags(m)) {
+              w.wl(s"out.writeSerializable(this.${idJava.field(f.ident)});")
+            } else {
+              w.wl(s"out.writeInt(this.${idJava.field(f.ident)}.ordinal());")
+            }
+          }
           case _ => throw new AssertionError("Unreachable")
         }
         case MList => {

--- a/test-suite/djinni/client_interface.djinni
+++ b/test-suite/djinni/client_interface.djinni
@@ -3,7 +3,7 @@ client_returned_record = record {
     record_id: i64;
     content: string;
     misc: optional<string>;
-}
+} deriving (parcelable)
 
 # Client interface
 client_interface = interface +j +o {

--- a/test-suite/djinni/constant_enum.djinni
+++ b/test-suite/djinni/constant_enum.djinni
@@ -7,7 +7,7 @@ constant_enum = enum {
 # Record containing enum constant
 constant_with_enum = record {
     const const_enum: constant_enum = constant_enum::some_value;
-}
+} deriving (parcelable)
 
 # Interface containing enum constant
 constant_interface_with_enum = interface +c {

--- a/test-suite/djinni/derivings.djinni
+++ b/test-suite/djinni/derivings.djinni
@@ -7,9 +7,9 @@ record_with_derivings = record {
     fsixtyfour: f64;
     d: date;
     s: string;
-} deriving (eq, ord)
+} deriving (eq, ord, parcelable)
 
 record_with_nested_derivings = record {
     key: i32;
     rec: record_with_derivings;
-} deriving (eq, ord)
+} deriving (eq, ord, parcelable)

--- a/test-suite/djinni/enum_flags.djinni
+++ b/test-suite/djinni/enum_flags.djinni
@@ -26,4 +26,4 @@ flag_roundtrip = interface +c {
 
 record_with_flags = record {
   access: access_flags;
-}
+} deriving (parcelable)

--- a/test-suite/djinni/map.djinni
+++ b/test-suite/djinni/map.djinni
@@ -1,8 +1,8 @@
 map_record = record {
     map: map<string, i64>;
 	imap: map<i32, i32>;
-}
+} deriving (parcelable)
 
 map_list_record = record {
     map_list: list<map<string, i64>>;
-}
+} deriving (parcelable)

--- a/test-suite/djinni/primitive_list.djinni
+++ b/test-suite/djinni/primitive_list.djinni
@@ -1,3 +1,3 @@
 primitive_list = record {
     list: list<i64>;
-}
+} deriving (parcelable)

--- a/test-suite/djinni/vendor/third-party/duration.yaml
+++ b/test-suite/djinni/vendor/third-party/duration.yaml
@@ -4,7 +4,7 @@
 # duration<f64, min> maps to std::chrono::duration<double, std::ratio<60>>
 ---
 name: duration
-typedef: 'record deriving(eq, ord)'
+typedef: 'record deriving(eq, ord, parcelable)'
 params: [rep, period]
 prefix: ''
 cpp:

--- a/test-suite/djinni/yaml-test.djinni
+++ b/test-suite/djinni/yaml-test.djinni
@@ -6,7 +6,7 @@ extern_record_with_derivings = record
 {
 	member: test_record_with_derivings;
 	e: test_color;
-} deriving(eq, ord)
+} deriving(eq, ord, parcelable)
 
 extern_interface_1 = interface +c
 {

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ClientReturnedRecord.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ClientReturnedRecord.java
@@ -7,7 +7,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 /** Record returned by a client */
-public class ClientReturnedRecord {
+public class ClientReturnedRecord implements android.os.Parcelable {
 
 
     /*package*/ final long mRecordId;
@@ -46,6 +46,47 @@ public class ClientReturnedRecord {
                 "," + "mContent=" + mContent +
                 "," + "mMisc=" + mMisc +
         "}";
+    }
+
+
+    public static final android.os.Parcelable.Creator<ClientReturnedRecord> CREATOR
+        = new android.os.Parcelable.Creator<ClientReturnedRecord>() {
+        @Override
+        public ClientReturnedRecord createFromParcel(android.os.Parcel in) {
+            return new ClientReturnedRecord(in);
+        }
+
+        @Override
+        public ClientReturnedRecord[] newArray(int size) {
+            return new ClientReturnedRecord[size];
+        }
+    };
+
+    public ClientReturnedRecord(android.os.Parcel in) {
+        this.mRecordId = in.readLong();
+        this.mContent = in.readString();
+        if (in.readByte() == 0) {
+            this.mMisc = null;
+        } else {
+            this.mMisc = in.readString();
+        }
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(android.os.Parcel out, int flags) {
+        out.writeLong(this.mRecordId);
+        out.writeString(this.mContent);
+        if (this.mMisc != null) {
+            out.writeByte((byte)1);
+            out.writeString(this.mMisc);
+        } else {
+            out.writeByte((byte)0);
+        }
     }
 
 }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantWithEnum.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/ConstantWithEnum.java
@@ -7,7 +7,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 /** Record containing enum constant */
-public class ConstantWithEnum {
+public class ConstantWithEnum implements android.os.Parcelable {
 
     @Nonnull
     public static final ConstantEnum CONST_ENUM = ConstantEnum.SOME_VALUE;
@@ -21,6 +21,32 @@ public class ConstantWithEnum {
     public String toString() {
         return "ConstantWithEnum{" +
         "}";
+    }
+
+
+    public static final android.os.Parcelable.Creator<ConstantWithEnum> CREATOR
+        = new android.os.Parcelable.Creator<ConstantWithEnum>() {
+        @Override
+        public ConstantWithEnum createFromParcel(android.os.Parcel in) {
+            return new ConstantWithEnum(in);
+        }
+
+        @Override
+        public ConstantWithEnum[] newArray(int size) {
+            return new ConstantWithEnum[size];
+        }
+    };
+
+    public ConstantWithEnum(android.os.Parcel in) {
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(android.os.Parcel out, int flags) {
     }
 
 }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/MapListRecord.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/MapListRecord.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
-public class MapListRecord {
+public class MapListRecord implements android.os.Parcelable {
 
 
     /*package*/ final ArrayList<HashMap<String, Long>> mMapList;
@@ -28,6 +28,35 @@ public class MapListRecord {
         return "MapListRecord{" +
                 "mMapList=" + mMapList +
         "}";
+    }
+
+
+    public static final android.os.Parcelable.Creator<MapListRecord> CREATOR
+        = new android.os.Parcelable.Creator<MapListRecord>() {
+        @Override
+        public MapListRecord createFromParcel(android.os.Parcel in) {
+            return new MapListRecord(in);
+        }
+
+        @Override
+        public MapListRecord[] newArray(int size) {
+            return new MapListRecord[size];
+        }
+    };
+
+    public MapListRecord(android.os.Parcel in) {
+        this.mMapList = new ArrayList<HashMap<String, Long>>();
+        in.readList(this.mMapList, getClass().getClassLoader());
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(android.os.Parcel out, int flags) {
+        out.writeList(this.mMapList);
     }
 
 }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/MapRecord.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/MapRecord.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
-public class MapRecord {
+public class MapRecord implements android.os.Parcelable {
 
 
     /*package*/ final HashMap<String, Long> mMap;
@@ -37,6 +37,38 @@ public class MapRecord {
                 "mMap=" + mMap +
                 "," + "mImap=" + mImap +
         "}";
+    }
+
+
+    public static final android.os.Parcelable.Creator<MapRecord> CREATOR
+        = new android.os.Parcelable.Creator<MapRecord>() {
+        @Override
+        public MapRecord createFromParcel(android.os.Parcel in) {
+            return new MapRecord(in);
+        }
+
+        @Override
+        public MapRecord[] newArray(int size) {
+            return new MapRecord[size];
+        }
+    };
+
+    public MapRecord(android.os.Parcel in) {
+        this.mMap = new HashMap<String, Long>();
+        in.readMap(this.mMap, getClass().getClassLoader());
+        this.mImap = new HashMap<Integer, Integer>();
+        in.readMap(this.mImap, getClass().getClassLoader());
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(android.os.Parcel out, int flags) {
+        out.writeMap(this.mMap);
+        out.writeMap(this.mImap);
     }
 
 }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/PrimitiveList.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/PrimitiveList.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
-public class PrimitiveList {
+public class PrimitiveList implements android.os.Parcelable {
 
 
     /*package*/ final ArrayList<Long> mList;
@@ -27,6 +27,35 @@ public class PrimitiveList {
         return "PrimitiveList{" +
                 "mList=" + mList +
         "}";
+    }
+
+
+    public static final android.os.Parcelable.Creator<PrimitiveList> CREATOR
+        = new android.os.Parcelable.Creator<PrimitiveList>() {
+        @Override
+        public PrimitiveList createFromParcel(android.os.Parcel in) {
+            return new PrimitiveList(in);
+        }
+
+        @Override
+        public PrimitiveList[] newArray(int size) {
+            return new PrimitiveList[size];
+        }
+    };
+
+    public PrimitiveList(android.os.Parcel in) {
+        this.mList = new ArrayList<Long>();
+        in.readList(this.mList, getClass().getClassLoader());
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(android.os.Parcel out, int flags) {
+        out.writeList(this.mList);
     }
 
 }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/RecordWithDerivings.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/RecordWithDerivings.java
@@ -7,7 +7,7 @@ import java.util.Date;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
-public class RecordWithDerivings implements Comparable<RecordWithDerivings> {
+public class RecordWithDerivings implements Comparable<RecordWithDerivings>, android.os.Parcelable {
 
 
     /*package*/ final byte mEight;
@@ -122,6 +122,48 @@ public class RecordWithDerivings implements Comparable<RecordWithDerivings> {
                 "," + "mD=" + mD +
                 "," + "mS=" + mS +
         "}";
+    }
+
+
+    public static final android.os.Parcelable.Creator<RecordWithDerivings> CREATOR
+        = new android.os.Parcelable.Creator<RecordWithDerivings>() {
+        @Override
+        public RecordWithDerivings createFromParcel(android.os.Parcel in) {
+            return new RecordWithDerivings(in);
+        }
+
+        @Override
+        public RecordWithDerivings[] newArray(int size) {
+            return new RecordWithDerivings[size];
+        }
+    };
+
+    public RecordWithDerivings(android.os.Parcel in) {
+        this.mEight = in.readByte();
+        this.mSixteen = (short)in.readInt();
+        this.mThirtytwo = in.readInt();
+        this.mSixtyfour = in.readLong();
+        this.mFthirtytwo = in.readFloat();
+        this.mFsixtyfour = in.readDouble();
+        this.mD = new Date(in.readLong());
+        this.mS = in.readString();
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(android.os.Parcel out, int flags) {
+        out.writeByte(this.mEight);
+        out.writeInt(this.mSixteen);
+        out.writeInt(this.mThirtytwo);
+        out.writeLong(this.mSixtyfour);
+        out.writeFloat(this.mFthirtytwo);
+        out.writeDouble(this.mFsixtyfour);
+        out.writeLong(this.mD.getTime());
+        out.writeString(this.mS);
     }
 
 

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/RecordWithFlags.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/RecordWithFlags.java
@@ -7,7 +7,7 @@ import java.util.EnumSet;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
-public class RecordWithFlags {
+public class RecordWithFlags implements android.os.Parcelable {
 
 
     /*package*/ final EnumSet<AccessFlags> mAccess;
@@ -27,6 +27,34 @@ public class RecordWithFlags {
         return "RecordWithFlags{" +
                 "mAccess=" + mAccess +
         "}";
+    }
+
+
+    public static final android.os.Parcelable.Creator<RecordWithFlags> CREATOR
+        = new android.os.Parcelable.Creator<RecordWithFlags>() {
+        @Override
+        public RecordWithFlags createFromParcel(android.os.Parcel in) {
+            return new RecordWithFlags(in);
+        }
+
+        @Override
+        public RecordWithFlags[] newArray(int size) {
+            return new RecordWithFlags[size];
+        }
+    };
+
+    public RecordWithFlags(android.os.Parcel in) {
+        this.mAccess = (EnumSet<AccessFlags>) in.readSerializable();
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(android.os.Parcel out, int flags) {
+        out.writeSerializable(this.mAccess);
     }
 
 }

--- a/test-suite/generated-src/java/com/dropbox/djinni/test/RecordWithNestedDerivings.java
+++ b/test-suite/generated-src/java/com/dropbox/djinni/test/RecordWithNestedDerivings.java
@@ -6,7 +6,7 @@ package com.dropbox.djinni.test;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
-public class RecordWithNestedDerivings implements Comparable<RecordWithNestedDerivings> {
+public class RecordWithNestedDerivings implements Comparable<RecordWithNestedDerivings>, android.os.Parcelable {
 
 
     /*package*/ final int mKey;
@@ -54,6 +54,36 @@ public class RecordWithNestedDerivings implements Comparable<RecordWithNestedDer
                 "mKey=" + mKey +
                 "," + "mRec=" + mRec +
         "}";
+    }
+
+
+    public static final android.os.Parcelable.Creator<RecordWithNestedDerivings> CREATOR
+        = new android.os.Parcelable.Creator<RecordWithNestedDerivings>() {
+        @Override
+        public RecordWithNestedDerivings createFromParcel(android.os.Parcel in) {
+            return new RecordWithNestedDerivings(in);
+        }
+
+        @Override
+        public RecordWithNestedDerivings[] newArray(int size) {
+            return new RecordWithNestedDerivings[size];
+        }
+    };
+
+    public RecordWithNestedDerivings(android.os.Parcel in) {
+        this.mKey = in.readInt();
+        this.mRec = new RecordWithDerivings(in);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(android.os.Parcel out, int flags) {
+        out.writeInt(this.mKey);
+        this.mRec.writeToParcel(out, flags);
     }
 
 

--- a/test-suite/run_djinni.sh
+++ b/test-suite/run_djinni.sh
@@ -67,6 +67,7 @@ fi
     --java-out "$temp_out_relative/java" \
     --java-package $java_package \
     --java-generate-interfaces true \
+    --java-implement-android-os-parcelable true \
     --java-nullable-annotation "javax.annotation.CheckForNull" \
     --java-nonnull-annotation "javax.annotation.Nonnull" \
     --java-use-final-for-record false \


### PR DESCRIPTION
The Flag type was added, but the support for parcelable for it was missing, so this PR add's it.
This also fixes https://github.com/dropbox/djinni/issues/431 and improves the test coverage for parcelable.