### PR TITLE
Updating be able to use newer Android NDK versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ intellij-plugin/djinni.jar
 
 # profiling output
 callgrind.out.*
+.project
+example/android/.settings

--- a/example/android/app/jni/Application.mk
+++ b/example/android/app/jni/Application.mk
@@ -2,10 +2,7 @@
 
 APP_ABI := all
 APP_OPTIM := release
-APP_PLATFORM := android-8
-# GCC 4.9 Toolchain - requires NDK r10
-NDK_TOOLCHAIN_VERSION = 4.9
-# GNU libc++ is the only Android STL which supports C++11 features
-APP_STL := gnustl_static
+APP_PLATFORM := android-16
+APP_STL := c++_static
 APP_BUILD_SCRIPT := jni/Android.mk
 APP_MODULES := libtextsort_jni


### PR DESCRIPTION
This patch upgrades the minimum for building using Android NDK 19:

* Upgrading the APP_PLATFORM to `android-16` (`Android NDK: android-8 is unsupported. Using minimum supported version android-16. `)
* Changing APP_STL from `gnustl_static` to `c++_static` (`Android NDK: APP_STL gnustl_static is no longer supported. Please switch to either c++_static or c++_shared. See https://developer.android.com/ndk/guides/cpp-support.html for more information.`)