### PR TITLE
Fix scala dependency resolving issue

### DIFF
--- a/src/support/sbt.resolvers.properties
+++ b/src/support/sbt.resolvers.properties
@@ -1,5 +1,5 @@
 [repositories]
 local
-ssl-typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+ssl-typesafe-ivy-releases: https://dl.bintray.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
 ssl-maven-central: https://repo1.maven.org/maven2
-ssl-sbt-plugins: https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/,[organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+ssl-sbt-plugins: https://dl.bintray.com/sbt/sbt-plugin-releases/,[organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]


### PR DESCRIPTION
At some point, the dependency site https://repo.typesafe.com/ started
forwarding to https://dl.bintray.com, but forwarding is doesn't occur
if url is a complete file path (e.g.
https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/main/0.13.17/ivys/ivy.xml)

So instead of depending on forwarding, the sbt.resolvers.properties
file now contains the forwarded path.