### PR TITLE
add support of symbols export define in cpp interfaces

### DIFF
--- a/src/source/CppGenerator.scala
+++ b/src/source/CppGenerator.scala
@@ -324,11 +324,17 @@ class CppGenerator(spec: Spec) extends Generator(spec) {
 
     val self = marshal.typename(ident, i)
     val methodNamesInScope = i.methods.map(m => idCpp.method(m.ident))
+    val exportDefine = spec.cppExportDefine.getOrElse("")
+
+    spec.cppExportDefineHeader match {
+      case Some(defineHeader) => refs.hpp.add("#include " + defineHeader)
+      case _ =>
+    }
 
     writeHppFile(ident, origin, refs.hpp, refs.hppFwds, w => {
       writeDoc(w, doc)
       writeCppTypeParams(w, typeParams)
-      w.w(s"class $self").bracedSemi {
+      w.w(s"class $exportDefine $self").bracedSemi {
         w.wlOutdent("public:")
         // Destructor
         w.wl(s"virtual ~$self() {}")

--- a/src/source/Main.scala
+++ b/src/source/Main.scala
@@ -37,6 +37,8 @@ object Main {
     var cppNnType: Option[String] = None
     var cppNnCheckExpression: Option[String] = None
     var cppUseWideStrings: Boolean = false
+    var cppExportDefine: Option[String] = None
+    var cppExportDefineHeader: Option[String] = None
     var javaOutFolder: Option[File] = None
     var javaPackage: Option[String] = None
     var javaClassAccessModifier: JavaAccessModifier.Value = JavaAccessModifier.Public
@@ -150,6 +152,10 @@ object Main {
         .text("The expression to use for building non-nullable pointers")
       opt[Boolean]( "cpp-use-wide-strings").valueName("<true/false>").foreach(x => cppUseWideStrings = x)
         .text("Use wide strings in C++ code (default: false)")
+      opt[String]("cpp-export-define").valueName("<header>").foreach(x => cppExportDefine = Some(x))
+        .text("The export define name for interfaces")
+      opt[String]("cpp-export-define-header").valueName("<header>").foreach(x => cppExportDefineHeader = Some(x))
+        .text("The header which defines export define")
       note("")
       opt[File]("jni-out").valueName("<out-folder>").foreach(x => jniOutFolder = Some(x))
         .text("The folder for the JNI C++ output files (Generator disabled if unspecified).")
@@ -329,6 +335,8 @@ object Main {
       cppNnType,
       cppNnCheckExpression,
       cppUseWideStrings,
+      cppExportDefine,
+      cppExportDefineHeader,
       jniOutFolder,
       jniHeaderOutFolder,
       jniIncludePrefix,

--- a/src/source/generator.scala
+++ b/src/source/generator.scala
@@ -54,6 +54,8 @@ package object generatorTools {
                    cppNnType: Option[String],
                    cppNnCheckExpression: Option[String],
                    cppUseWideStrings: Boolean,
+                   cppExportDefine: Option[String],
+                   cppExportDefineHeader: Option[String],
                    jniOutFolder: Option[File],
                    jniHeaderOutFolder: Option[File],
                    jniIncludePrefix: String,


### PR DESCRIPTION
Hello!

I've added basic support of define for cpp djinni interface symbols exporting. like was mentioned in https://github.com/dropbox/djinni/issues/114
