### PR TITLE
Only set `-fobjc-arc` for valid languages on djinni_support_lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ if(DJINNI_WITH_OBJC)
   target_include_directories(djinni_support_lib PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/support-lib/objc/>")
   target_sources(djinni_support_lib PRIVATE ${SRC_OBJC})
   source_group("objc" FILES ${SRC_OBJC})
-  target_compile_options(djinni_support_lib PUBLIC "-fobjc-arc")
+  target_compile_options(djinni_support_lib PUBLIC "$<$<COMPILE_LANGUAGE:CXX,OBJC,OBJCXX>:-fobjc-arc>")
 endif()
 
 # JNI support


### PR DESCRIPTION
`-fobjc-arc` is set as a PUBLIC compile option on djinni_support_lib,
meaning it also gets set for any targets that consume Djinni. However
the Swift compiler doesn't understand this option and will throw an
error if it is present. Any targets that contain Swift code and consume
Djinni, even if indirectly, will thus fail to build.

This change causes the `-fobjc-arc` option to only be set when the
language used for that compilation matches CXX, OBJC, or OBJCXX. CXX is
present because in CMake versions prior to 3.16 or if OBJC/OBJCXX is
not enabled, .m and .mm files are treated as CXX.